### PR TITLE
Changed Read the Docs master file to index.rst

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,3 +59,6 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+# Change Read the Docs master file to index.rst 
+master_doc = 'index'


### PR DESCRIPTION
Read the Docs assumes content.rst as the master file. This changes the default to index.rst (which our project uses.)