### PR TITLE
Sorted histogram classes and components layout

### DIFF
--- a/backwardcompatibilityml/helpers/training.py
+++ b/backwardcompatibilityml/helpers/training.py
@@ -528,6 +528,7 @@ def evaluate_model_performance_and_compatibility_on_dataset(h1, h2, dataset, per
         ],
 
         "h2_error_fraction_by_class": h2_ds_error_fraction_by_class,
+        "sorted_classes": sorted(list(classes)),
         "h2_performance": h2_performance,
         "btc": btc,
         "bec": bec

--- a/backwardcompatibilityml/widget/resources/widget.css
+++ b/backwardcompatibilityml/widget/resources/widget.css
@@ -37,8 +37,6 @@ label {
 .plot {
   position: relative;
   display: inline-block;
-/*  margin-left: 20px;
-  margin-right:20px;*/
 }
 
 .plot svg {

--- a/backwardcompatibilityml/widget/resources/widget.css
+++ b/backwardcompatibilityml/widget/resources/widget.css
@@ -37,8 +37,42 @@ label {
 .plot {
   position: relative;
   display: inline-block;
-  margin-left: 20px;
-  margin-right:20px;
+/*  margin-left: 20px;
+  margin-right:20px;*/
+}
+
+.plot svg {
+  background-color: white
+}
+
+.plot-btc {
+  background-color: lightgrey;
+  padding-left: 20px;
+  padding-right:20px;
+  padding-top: 20px;
+  padding-bottom: 10px;
+}
+
+.plot-bec {
+  background-color: lightgrey;
+  padding-right:20px;
+  padding-top: 20px;
+  padding-bottom: 10px;
+}
+
+.plot-venn {
+  background-color: lightgrey;
+  padding-left: 20px;
+  padding-right:20px;
+  padding-top: 20px;
+  padding-bottom: 10px;
+}
+
+.plot-distribution {
+  background-color: lightgrey;
+  padding-right:20px;
+  padding-top: 20px;
+  padding-bottom: 10px;
 }
 
 .tooltip {
@@ -51,7 +85,7 @@ label {
 }
 
 .table {
-  width: 600px;
+  width: 700px;
   text-align: center;
   background-color: lightblue;
 }
@@ -62,7 +96,7 @@ label {
 }
 
 .data-selector {
-  width: 600px;
+  width: 700px;
   text-align: left;
 }
 
@@ -138,7 +172,7 @@ label {
 }
 
 .model-details {
-  width: 600px;
+  width: 700px;
   border-style: solid;
   border-width: 1px;
 }

--- a/widget/IncompatiblePointDistribution.tsx
+++ b/widget/IncompatiblePointDistribution.tsx
@@ -118,7 +118,7 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
 
   render() {
     return (
-      <div className="plot" ref={this.node} />
+      <div className="plot plot-distribution" ref={this.node} />
     );
   }
 }

--- a/widget/IncompatiblePointDistribution.tsx
+++ b/widget/IncompatiblePointDistribution.tsx
@@ -48,7 +48,7 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
 
     var margin = { top: 15, right: 15, bottom: 50, left: 55 }
     var h = 250 - margin.top - margin.bottom
-    var w = 250 - margin.left - margin.right
+    var w = 250;
 
     // SVG
     d3.select("#incompatiblepointdistribution").remove();
@@ -64,7 +64,14 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
        .text("Distribution of Incompatible Points")
 
     if (this.props.selectedDataPoint != null) {
-      var dataRows = this.props.selectedDataPoint.h2_error_fraction_by_class;
+      // Sort the data into the dataRows based on the ordering of the sorted classes
+      var dataRows = [];
+      for (var i=0; i < this.props.selectedDataPoint.sorted_classes.length; i++) {
+        var instanceClass = this.props.selectedDataPoint.sorted_classes[i];
+        var dataRow = this.props.selectedDataPoint.h2_error_fraction_by_class.filter(
+          dataDict => (dataDict["class"] == instanceClass)).pop();
+        dataRows.push(dataRow);
+      }
 
       var xScale = d3.scaleBand().range([0, w]).padding(0.4),
           yScale = d3.scaleLinear().range([h, 0]);

--- a/widget/IntersectionBetweenModelErrors.tsx
+++ b/widget/IntersectionBetweenModelErrors.tsx
@@ -49,7 +49,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
 
     var margin = { top: 15, right: 15, bottom: 50, left: 55 }
     var h = 250 - margin.top - margin.bottom
-    var w = 250 - margin.left - margin.right
+    var w = 320 - margin.left - margin.right
 
     var tooltip = d3.select("#venntooltip");
 
@@ -60,7 +60,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
         .attr('height',h + margin.top + margin.bottom)
         .attr('width',w + margin.left + margin.right)
       .append('g')
-        .attr('transform',`translate(0,${margin.top + 15})`)
+        .attr('transform',`translate(55,${margin.top + 15})`)
 
     svg.append('text')
       .attr('id','xAxisLabel')
@@ -76,7 +76,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
     svg.append("rect")
       .attr("x", 0)
       .attr("y", 0)
-      .attr("width", w + margin.left + margin.right)
+      .attr("width", 240)
       .attr("height", h)
       .attr("fill", "rgba(255, 255, 255, 0.8)")
       .attr("stroke", "black")
@@ -333,7 +333,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
 
   render() {
     return (
-      <div className="plot" ref={this.node} id="venndiagramplot">
+      <div className="plot plot-venn" ref={this.node} id="venndiagramplot">
         <div className="tooltip" id="venntooltip" />
       </div>
     );

--- a/widget/PerformanceCompatibility.tsx
+++ b/widget/PerformanceCompatibility.tsx
@@ -74,7 +74,7 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
 
     var margin = { top: 15, right: 15, bottom: 50, left: 55 }
     var h = 250 - margin.top - margin.bottom
-    var w = 250 - margin.left - margin.right
+    var w = 320 - margin.left - margin.right
 
     var formatPercentX = d3.format('.3f');
     var formatPercentY = d3.format('.2f');
@@ -106,23 +106,14 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
       allDataPoints = allDataPoints.concat(data.filter(d => (d["testing"] && d["strict-imitation"])));
     }
 
-    // var xScale = d3.scaleLinear()
-    //   .domain([
-    //     d3.min([0,d3.min(data,function (d) { return d[_this.props.compatibilityScoreType] })]),
-    //     d3.max([0,d3.max(data,function (d) { return d[_this.props.compatibilityScoreType] })])
-    //     ])
-    //   .range([0,w])
-    // var yScale = d3.scaleLinear()
-    //   .domain([
-    //     d3.min([0,d3.min(data,function (d) { return d['performance'] })]),
-    //     d3.max([0,d3.max(data,function (d) { return d['performance'] })])
-    //     ])
-    //   .range([h,0])
+    var btcValues = allDataPoints.map(d => d["btc"]);
+    var becValues = allDataPoints.map(d => d["bec"]);
+    var allValues = [].concat(btcValues).concat(becValues);
 
     var xScale = d3.scaleLinear()
       .domain([
-        d3.min(allDataPoints,function (d) { return d[_this.props.compatibilityScoreType] }),
-        d3.max(allDataPoints,function (d) { return d[_this.props.compatibilityScoreType] })
+        d3.min(allValues),
+        d3.max(allValues)
         ])
       .range([0,w])
     var yScale = d3.scaleLinear()
@@ -132,11 +123,6 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
         ])
       .range([h,0])
 
-    // d3.select(`#lambdactooltip-${_this.props.compatibilityScoreType}`).remove();
-    // var tooltip = body.append("div")
-    //   .attr("class", "lambdactooltip")
-    //   .attr("id", `lambdactooltip-${_this.props.compatibilityScoreType}`)
-    //   .style("position", "absolute");
     var tooltip = d3.select(`#lambdactooltip-${_this.props.compatibilityScoreType}`);
 
     // SVG
@@ -194,31 +180,15 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
         .attr("fill", "black");
 
     svg.append("line")
-      .attr("x1", xScale(d3.min(allDataPoints,function (d) { return d[_this.props.compatibilityScoreType] }) - 0.005))
+      .attr("x1", xScale(d3.min(allValues) - 0.005))
       .attr("y1", yScale(this.props.h1Performance))
-      .attr("x2", xScale(d3.max(allDataPoints,function (d) { return d[_this.props.compatibilityScoreType] })))
+      .attr("x2", xScale(d3.max(allValues)))
       .attr("y2", yScale(this.props.h1Performance))
       .attr("stroke", "black")
       .attr("stroke-width", "1px")
       .attr("stroke-dasharray", "5,5");
 
     function drawCircles() {
-      // var allDataPoints = [];
-      // if (_this.state.training && _this.state.newError) {
-      //   allDataPoints = allDataPoints.concat(data.filter(d => (d["training"] && d["new-error"])));
-      // }
-
-      // if (_this.state.training && _this.state.strictImitation) {
-      //   allDataPoints = allDataPoints.concat(data.filter(d => (d["training"] && d["strict-imitation"])));
-      // }
-
-      // if (_this.state.testing && _this.state.newError) {
-      //   allDataPoints = allDataPoints.concat(data.filter(d => (d["testing"] && d["new-error"])));
-      // }
-
-      // if (_this.state.testing && _this.state.strictImitation) {
-      //   allDataPoints = allDataPoints.concat(data.filter(d => (d["testing"] && d["strict-imitation"])));
-      // }
 
       var circles = svg.selectAll('circle')
           .data(allDataPoints)
@@ -292,8 +262,9 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
   }
 
   render() {
+    let classes = `plot plot-${this.props.compatibilityScoreType}`;
     return (
-      <div className="plot" ref={this.node} id={`scatterplot-${this.props.compatibilityScoreType}`}>
+      <div className={classes} ref={this.node} id={`scatterplot-${this.props.compatibilityScoreType}`}>
         <div className="tooltip" id={`lambdactooltip-${this.props.compatibilityScoreType}`} />
       </div>
     );


### PR DESCRIPTION
1. I have the histogram render classes in order.
2. Adjusted the layout of the components.
<img width="724" alt="widget-ui-new-layout" src="https://user-images.githubusercontent.com/680818/96082846-d81f7b80-0e70-11eb-9eed-d69a318d28e7.png">

I've kept the layout changes in a separate commit, so if you don't like them, they can be reverted.