### PR TITLE
Performance function name in scatterplots

### DIFF
--- a/backwardcompatibilityml/helpers/training.py
+++ b/backwardcompatibilityml/helpers/training.py
@@ -634,8 +634,13 @@ def compatibility_sweep(sweeps_folder_path, number_of_epochs, h1, h2,
         StrictImitationLossClass: The class of the Strict Imitation style loss
             function to be instantiated and used to perform compatibility
             constrained training of our model h2.
-        performance_metric: Optional performance metric to be used when evaluating the model.
-            If not specified then accuracy is used.
+        performance_metric: A function to evaluate model performance. The function is
+            expected to have the following signature:
+                metric(model, dataset, device)
+                    model: The model being evaluated
+                    dataset: The dataset as a list of (input, target) pairs
+                    device: The device Pytorch is using for training - "cpu" or "cuda"
+            If unspecified, then accuracy is used.
         lambda_c_stepsize: The increments of lambda_c to use as we sweep the parameter
             space between 0.0 and 1.0.
         percent_complete_queue: Optional thread safe queue to use for logging the

--- a/backwardcompatibilityml/metrics.py
+++ b/backwardcompatibilityml/metrics.py
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import torch
+from sklearn.metrics import accuracy_score
+
+
+def model_accuracy(model, dataset, device="cpu"):
+    model_performance = 0
+    number_of_batches = len(dataset)
+    with torch.no_grad():
+        for data, target in dataset:
+            if device != "cpu":
+                data = data.to(device)
+                target = target.to(device)
+            _, _, output_logsoftmax = model(data)
+            output_labels = torch.argmax(output_logsoftmax, 1)
+            if device != "cpu":
+                output_labels = output_labels.cpu()
+                target = target.cpu()
+            performance = accuracy_score(output_labels.numpy(), target.numpy())
+            model_performance += performance
+            # _clean_from_gpu([data, target])
+
+        model_performance /= number_of_batches
+    return model_performance

--- a/backwardcompatibilityml/sweep_management.py
+++ b/backwardcompatibilityml/sweep_management.py
@@ -6,6 +6,7 @@ import json
 import threading
 from queue import Queue
 from backwardcompatibilityml.helpers import training
+from backwardcompatibilityml.metrics import model_accuracy
 
 
 class SweepManager(object):
@@ -58,6 +59,7 @@ class SweepManager(object):
                  NewErrorLossClass, StrictImitationLossClass, lambda_c_stepsize=0.25,
                  new_error_loss_kwargs=None,
                  strict_imitation_loss_kwargs=None,
+                 performance_metric=model_accuracy,
                  device="cpu"):
         self.folder_name = folder_name
         self.number_of_epochs = number_of_epochs
@@ -71,6 +73,7 @@ class SweepManager(object):
         self.optimizer_kwargs = optimizer_kwargs
         self.NewErrorLossClass = NewErrorLossClass
         self.StrictImitationLossClass = StrictImitationLossClass
+        self.performance_metric = performance_metric
         self.lambda_c_stepsize = lambda_c_stepsize
         self.new_error_loss_kwargs = new_error_loss_kwargs
         self.strict_imitation_loss_kwargs = strict_imitation_loss_kwargs
@@ -83,7 +86,8 @@ class SweepManager(object):
                   self.training_set, self.test_set,
                   self.batch_size_train, self.batch_size_test,
                   self.OptimizerClass, self.optimizer_kwargs,
-                  self.NewErrorLossClass, self.StrictImitationLossClass,),
+                  self.NewErrorLossClass, self.StrictImitationLossClass,
+                  self.performance_metric,),
             kwargs={
                 "lambda_c_stepsize": self.lambda_c_stepsize,
                 "percent_complete_queue": self.percent_complete_queue,
@@ -114,8 +118,12 @@ class SweepManager(object):
         return self.last_sweep_status
 
     def get_sweep_summary(self):
+        metric_name = self.performance_metric.__name__
+        if metric_name == "model_accuracy":
+            metric_name = "Accuracy"
         sweep_summary = {
             "h1_performance": None,
+            "performance_metric": metric_name,
             "data": []
         }
 

--- a/backwardcompatibilityml/sweep_management.py
+++ b/backwardcompatibilityml/sweep_management.py
@@ -118,12 +118,9 @@ class SweepManager(object):
         return self.last_sweep_status
 
     def get_sweep_summary(self):
-        metric_name = self.performance_metric.__name__
-        if metric_name == "model_accuracy":
-            metric_name = "Accuracy"
         sweep_summary = {
             "h1_performance": None,
-            "performance_metric": metric_name,
+            "performance_metric": self.performance_metric.__name__,
             "data": []
         }
 

--- a/backwardcompatibilityml/widget/compatibility_analysis.py
+++ b/backwardcompatibilityml/widget/compatibility_analysis.py
@@ -12,6 +12,7 @@ import torch.optim as optim
 from flask import Response
 from backwardcompatibilityml import loss
 from backwardcompatibilityml.sweep_management import SweepManager
+from backwardcompatibilityml.metrics import model_accuracy
 from rai_core_flask.flask_helper import FlaskHelper
 from rai_core_flask.environments import (
     AzureNBEnvironment,
@@ -169,6 +170,8 @@ class CompatibilityAnalysis(object):
         StrictImitationLossClass: The class of the Strict Imitation style loss
             function to be instantiated and used to perform compatibility
             constrained training of our model h2.
+        performance_metric: A function to evaluate model performance.
+            If none, accuracy will be used.
         port: An integer value to indicate the port to which the Flask service
             should bind.
         device: A string with values either "cpu" or "cuda" to indicate the
@@ -182,6 +185,7 @@ class CompatibilityAnalysis(object):
                  batch_size_train, batch_size_test, lambda_c_stepsize=0.25,
                  OptimizerClass=None, optimizer_kwargs=None,
                  NewErrorLossClass=None, StrictImitationLossClass=None,
+                 performance_metric=model_accuracy,
                  port=None, new_error_loss_kwargs=None,
                  strict_imitation_loss_kwargs=None, device="cpu"):
         if OptimizerClass is None:
@@ -211,6 +215,7 @@ class CompatibilityAnalysis(object):
             lambda_c_stepsize=lambda_c_stepsize,
             new_error_loss_kwargs=new_error_loss_kwargs,
             strict_imitation_loss_kwargs=strict_imitation_loss_kwargs,
+            performance_metric=performance_metric,
             device=device)
 
         self.flask_service = FlaskHelper(ip="0.0.0.0", port=port)

--- a/backwardcompatibilityml/widget/compatibility_analysis.py
+++ b/backwardcompatibilityml/widget/compatibility_analysis.py
@@ -170,8 +170,13 @@ class CompatibilityAnalysis(object):
         StrictImitationLossClass: The class of the Strict Imitation style loss
             function to be instantiated and used to perform compatibility
             constrained training of our model h2.
-        performance_metric: A function to evaluate model performance.
-            If none, accuracy will be used.
+        performance_metric: A function to evaluate model performance. The function is
+            expected to have the following signature:
+                metric(model, dataset, device)
+                    model: The model being evaluated
+                    dataset: The dataset as a list of (input, target) pairs
+                    device: The device Pytorch is using for training - "cpu" or "cuda"
+            If unspecified, then accuracy is used.
         port: An integer value to indicate the port to which the Flask service
             should bind.
         device: A string with values either "cpu" or "cuda" to indicate the

--- a/widget/MainContainer.tsx
+++ b/widget/MainContainer.tsx
@@ -103,7 +103,7 @@ function Container({
             <PerformanceCompatibility
               data={data.data}
               h1Performance={data.h1_performance}
-              performanceFunctionLabel={data.performance_metric}
+              performanceMetric={data.performance_metric}
               training={training}
               testing={testing}
               newError={newError}
@@ -116,7 +116,7 @@ function Container({
             <PerformanceCompatibility
               data={data.data}
               h1Performance={data.h1_performance}
-              performanceFunctionLabel={data.performance_metric}
+              performanceMetric={data.performance_metric}
               training={training}
               testing={testing}
               newError={newError}

--- a/widget/MainContainer.tsx
+++ b/widget/MainContainer.tsx
@@ -103,7 +103,7 @@ function Container({
             <PerformanceCompatibility
               data={data.data}
               h1Performance={data.h1_performance}
-              performanceFunctionLabel="Performance"
+              performanceFunctionLabel={data.performance_metric}
               training={training}
               testing={testing}
               newError={newError}
@@ -116,7 +116,7 @@ function Container({
             <PerformanceCompatibility
               data={data.data}
               h1Performance={data.h1_performance}
-              performanceFunctionLabel="Performance"
+              performanceFunctionLabel={data.performance_metric}
               training={training}
               testing={testing}
               newError={newError}

--- a/widget/MainContainer.tsx
+++ b/widget/MainContainer.tsx
@@ -103,6 +103,7 @@ function Container({
             <PerformanceCompatibility
               data={data.data}
               h1Performance={data.h1_performance}
+              performanceFunctionLabel="Performance"
               training={training}
               testing={testing}
               newError={newError}
@@ -115,6 +116,7 @@ function Container({
             <PerformanceCompatibility
               data={data.data}
               h1Performance={data.h1_performance}
+              performanceFunctionLabel="Performance"
               training={training}
               testing={testing}
               newError={newError}

--- a/widget/PerformanceCompatibility.tsx
+++ b/widget/PerformanceCompatibility.tsx
@@ -25,7 +25,7 @@ type PerformanceCompatibilityProps = {
   strictImitation: boolean,
   selectedDataPoint: any,
   compatibilityScoreType: string,
-  performanceFunctionLabel: string,
+  performanceMetric: string,
   selectDataPoint: (d: any) => void,
   getModelEvaluationData: (evaluationId: number) => void
 }
@@ -175,7 +175,7 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
         .attr('y',-50)
         .attr('dy','.71em')
         .style('text-anchor','end')
-        .text(this.props.performanceFunctionLabel)
+        .text(this.props.performanceMetric)
         .attr("font-family", "sans-serif")
         .attr("font-size", "20px")
         .attr("fill", "black");

--- a/widget/PerformanceCompatibility.tsx
+++ b/widget/PerformanceCompatibility.tsx
@@ -25,6 +25,7 @@ type PerformanceCompatibilityProps = {
   strictImitation: boolean,
   selectedDataPoint: any,
   compatibilityScoreType: string,
+  performanceFunctionLabel: string,
   selectDataPoint: (d: any) => void,
   getModelEvaluationData: (evaluationId: number) => void
 }
@@ -174,7 +175,7 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
         .attr('y',-50)
         .attr('dy','.71em')
         .style('text-anchor','end')
-        .text('Performance')
+        .text(this.props.performanceFunctionLabel)
         .attr("font-family", "sans-serif")
         .attr("font-size", "20px")
         .attr("fill", "black");

--- a/widget/PerformanceCompatibility.tsx
+++ b/widget/PerformanceCompatibility.tsx
@@ -171,7 +171,7 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
       .append('text')
         .attr('id', 'yAxisLabel')
         .attr('transform','rotate(-90)')
-        .attr('x',-h/2)
+        .attr('x',-h/2+2.5*this.props.performanceMetric.length)
         .attr('y',-50)
         .attr('dy','.71em')
         .style('text-anchor','end')


### PR DESCRIPTION
Displays the performance function name in the scatterplot.

![image](https://user-images.githubusercontent.com/1587757/96935214-79618f80-1478-11eb-9b32-f1f6a4f4ec4e.png)

- The performance metric name is now a prop on the PerformanceCompatibility component
- Performance metric can be specified with CompatibilityAnalysis constructor
- Rewrote and moved around some code to pass around performance_metric and fill it in with a default accuracy function if it was not specified by the user

Closes #31 