### PR TITLE
Fix for loop check when adding error instances to errors table

### DIFF
--- a/widget/ErrorInstancesTable.tsx
+++ b/widget/ErrorInstancesTable.tsx
@@ -71,8 +71,8 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
 
     var items = [];
     for(var i=(this.state.page * this.props.pageSize);
-        i < Math.min((this.state.page * this.props.pageSize) + this.props.pageSize),
-                     this.props.selectedDataPoint.error_instances.length;
+        i < Math.min((this.state.page * this.props.pageSize) + this.props.pageSize,
+                     this.props.selectedDataPoint.error_instances.length);
         i++) {
       items.push(this.props.selectedDataPoint.error_instances[i]);
     }


### PR DESCRIPTION
Fixes a misplaced right parenthesis causing an infinite loop.