### PR TITLE
Histogram - highlight column on click with CSS style

### DIFF
--- a/widget/IncompatiblePointDistribution.tsx
+++ b/widget/IncompatiblePointDistribution.tsx
@@ -8,6 +8,7 @@ import * as d3 from "d3";
 
 type IncompatiblePointDistributionState = {
   selectedDataPoint: any,
+  highlightedClass?: number,
   page: number
 }
 
@@ -28,6 +29,7 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
 
     this.state = {
       selectedDataPoint: this.props.selectedDataPoint,
+      highlightedClass: null,
       page: 0
     };
 
@@ -145,8 +147,10 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
          .attr("y", function(d) { return yScale(d.incompatibleInstanceIds.length/totalIncompatible * 100); })
          .attr("width", xScale.bandwidth())
          .attr("height", function(d) { return h - yScale(d.incompatibleInstanceIds.length/totalIncompatible * 100); })
+         .classed("highlighted-bar", function(d) { return d.class == _this.state.highlightedClass })
          .on("click", function(d) {
            _this.props.filterByInstanceIds(d.incompatibleInstanceIds);
+           _this.setState({ highlightedClass: d.class });
          });
       }
   }

--- a/widget/widget.css
+++ b/widget/widget.css
@@ -221,3 +221,8 @@ label {
   font-size: 10px;
   font-weight: normal;
 }
+
+.highlighted-bar {
+  stroke-width: 2;
+  stroke: rgb(0,0,0);
+}


### PR DESCRIPTION
This PR is for https://github.com/microsoft/BackwardCompatibilityML/issues/57

Clicking on a column will give it a black border. Changing the style of the highlight only requires updating a new CSS class `highlighted-bar`.

![image](https://user-images.githubusercontent.com/1587757/98418627-2b33bb00-2038-11eb-9f02-7b177217f0b0.png)
