### PR TITLE
Make sure to reset the filter to null between selection of data points

### DIFF
--- a/widget/reducers.ts
+++ b/widget/reducers.ts
@@ -31,23 +31,23 @@ function rootReducer(state = initialState, action) {
           return Object.assign({}, state, {strictImitation: !state.strictImitation});
 
         case "SELECT_DATA_POINT":
-          return Object.assign({}, state, {selectedDataPoint: action.dataPoint});
+          return Object.assign({}, state, {filterInstances: null, selectedDataPoint: action.dataPoint});
 
         case "REQUEST_TRAINING_AND_TESTING_DATA":
-          return Object.assign({}, state, {loading: true});
+          return Object.assign({}, state, {filterInstances: null, loading: true});
 
         case "REQUEST_TRAINING_AND_TESTING_DATA_SUCCEEDED":
-          return Object.assign({}, state, {data: action.data, loading: false, error: null});
+          return Object.assign({}, state, {filterInstances: null, data: action.data, loading: false, error: null});
 
         case "REQUEST_TRAINING_AND_TESTING_DATA_FAILED":
           console.log("Error: ", action.error);
           return Object.assign({}, state, {error: "Failed to load training and testing data", loading: false});
 
         case "REQUEST_MODEL_EVALUATION_DATA":
-          return Object.assign({}, state, {loading: true});
+          return Object.assign({}, state, {filterInstances: null, loading: true});
 
         case "REQUEST_MODEL_EVALUATION_DATA_SUCCEEDED":
-          return Object.assign({}, state, {selectedDataPoint: action.evaluationData, loading: false});
+          return Object.assign({}, state, {filterInstances: null, selectedDataPoint: action.evaluationData, loading: false});
 
         case "REQUEST_MODEL_EVALUATION_DATA_FAILED":
           console.log("Error: ", action.error);


### PR DESCRIPTION
This PR sorts out the issue where sometimes the error instances table was empty even though we were exploring a data point that had classification errors. This was due to the filter not getting reset to null between data point selection. We solve it by making sure to set the filter to null in the appropriate places.
