### PR TITLE
Info tooltips

### DIFF
--- a/widget/IncompatiblePointDistribution.tsx
+++ b/widget/IncompatiblePointDistribution.tsx
@@ -10,12 +10,13 @@ import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 
 type IncompatiblePointDistributionState = {
   selectedDataPoint: any,
-  highlightedClass?: number,
   page: number
 }
 
 type IncompatiblePointDistributionProps = {
   selectedDataPoint: any,
+  selectedClass?: number,
+  setSelectedClass: any,
   pageSize?: number,
   filterByInstanceIds: any
 }
@@ -31,7 +32,6 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
 
     this.state = {
       selectedDataPoint: this.props.selectedDataPoint,
-      highlightedClass: null,
       page: 0
     };
 
@@ -48,7 +48,6 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
   componentWillReceiveProps(nextProps) {
     this.setState({
       selectedDataPoint: nextProps.selectedDataPoint,
-      highlightedClass: null
     });
   }
 
@@ -144,10 +143,10 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
          .attr("y", function(d) { return yScale(d.incompatibleInstanceIds.length/totalIncompatible * 100); })
          .attr("width", xScale.bandwidth())
          .attr("height", function(d) { return h - yScale(d.incompatibleInstanceIds.length/totalIncompatible * 100); })
-         .classed("highlighted-bar", function(d) { return d.class == _this.state.highlightedClass })
+         .classed("highlighted-bar", function(d) { return d.class == _this.props.selectedClass })
          .on("click", function(d) {
            _this.props.filterByInstanceIds(d.incompatibleInstanceIds);
-           _this.setState({ highlightedClass: d.class });
+           _this.props.setSelectedClass(d.class);
          });
       }
   }

--- a/widget/IncompatiblePointDistribution.tsx
+++ b/widget/IncompatiblePointDistribution.tsx
@@ -4,6 +4,8 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import * as d3 from "d3";
+import { InfoTooltip } from "./InfoTooltip.tsx"
+import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 
 
 type IncompatiblePointDistributionState = {
@@ -58,7 +60,7 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
     var _this = this;
     var body = d3.select(this.node.current);
 
-    var margin = { top: 15, right: 15, bottom: 50, left: 55 }
+    var margin = { top: 5, right: 15, bottom: 50, left: 55 }
     var h = 250 - margin.top - margin.bottom
     var w = 250;
 
@@ -69,12 +71,6 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
         .attr('height',h + margin.top + margin.bottom)
         .attr('width',w + margin.left + margin.right)
         .attr('float', 'left');
-
-    svg.append("text")
-       .attr("x", margin.left + 20)
-       .attr("y", 15)
-       .attr("font-size", "10px")
-       .text("Distribution of Incompatible Points")
 
     if (this.props.selectedDataPoint != null) {
       // Sort the data into the dataRows based on the ordering of the sorted classes
@@ -112,7 +108,7 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
           yScale = d3.scaleLinear().range([h, 0]);
 
       var g = svg.append("g")
-                 .attr("transform", "translate(" + 55 + "," + 30 + ")");
+                 .attr("transform", "translate(" + 55 + "," + margin.top + ")");
 
         xScale.domain(dataRows.map(function(d) { return d.class; }));
         yScale.domain([0, 100]);
@@ -159,8 +155,13 @@ class IncompatiblePointDistribution extends Component<IncompatiblePointDistribut
   render() {
     let numClasses = this.props.selectedDataPoint?.sorted_classes?.length ?? 0;
     let numPages = Math.ceil(numClasses/this.props.pageSize) - 1;
+    const message = "Displays distribution of errors not made by the previous model as they occur across classes of the newly trained model.​";
     return (
       <div className="plot plot-distribution">
+        <div className="plot-title-row">
+          Distribution of Incompatible Points
+          <InfoTooltip message={message} direction={DirectionalHint.topCenter} />
+        </div>
         <div ref={this.node}/>
         <div className="page-button-row">
           <button onClick={() => {

--- a/widget/InfoTooltip.tsx
+++ b/widget/InfoTooltip.tsx
@@ -32,7 +32,7 @@ export const InfoTooltip: FunctionComponent<InfoTooltipProps> = ({ message, dire
     >
       <IconButton iconProps={{ iconName: 'Info' }}
                   aria-describedby={tooltipId}
-                  styles={{icon: {fontSize: '18px', color: "black"}}}/>
+                  styles={{icon: {fontSize: '18px', color: "black"}, root: {width: "24px", height: "18px"}}}/>
     </TooltipHost>
   );
 };

--- a/widget/InfoTooltip.tsx
+++ b/widget/InfoTooltip.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React, { FunctionComponent } from "react";
+import ReactDOM from "react-dom";
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import {
+  TooltipHost,
+  TooltipDelay,
+  DirectionalHint,
+  ITooltipProps,
+  ITooltipHostStyles,
+} from 'office-ui-fabric-react/lib/Tooltip';
+import { useId } from '@uifabric/react-hooks';
+
+type InfoTooltipProps = {
+  message: string
+  direction: DirectionalHint
+}
+
+export const InfoTooltip: FunctionComponent<InfoTooltipProps> = ({ message, direction }) => {
+  // Use useId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string and manually ensure uniqueness.)
+  const tooltipId = useId('tooltip');
+
+  return (
+    <TooltipHost
+      delay={TooltipDelay.zero}
+      id={tooltipId}
+      directionalHint={direction}
+      content={message}
+    >
+      <IconButton iconProps={{ iconName: 'Info' }}
+                  aria-describedby={tooltipId}
+                  styles={{icon: {fontSize: '12px'}}}/>
+    </TooltipHost>
+  );
+};

--- a/widget/InfoTooltip.tsx
+++ b/widget/InfoTooltip.tsx
@@ -29,6 +29,7 @@ export const InfoTooltip: FunctionComponent<InfoTooltipProps> = ({ message, dire
       id={tooltipId}
       directionalHint={direction}
       content={message}
+      styles={{root: {width: "24px", height: "18px"}}}
     >
       <IconButton iconProps={{ iconName: 'Info' }}
                   aria-describedby={tooltipId}

--- a/widget/InfoTooltip.tsx
+++ b/widget/InfoTooltip.tsx
@@ -32,7 +32,7 @@ export const InfoTooltip: FunctionComponent<InfoTooltipProps> = ({ message, dire
     >
       <IconButton iconProps={{ iconName: 'Info' }}
                   aria-describedby={tooltipId}
-                  styles={{icon: {fontSize: '12px'}}}/>
+                  styles={{icon: {fontSize: '18px', color: "black"}}}/>
     </TooltipHost>
   );
 };

--- a/widget/IntersectionBetweenModelErrors.tsx
+++ b/widget/IntersectionBetweenModelErrors.tsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom";
 import * as d3 from "d3";
 import { bisect } from "./optimization.tsx";
 import { InfoTooltip } from "./InfoTooltip.tsx";
-import { VennLegend } from "./VennLegend.tsx";
+import VennLegend from "./VennLegend.tsx";
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 
 function calculateCircleRadiiAndDistance(a, b, ab, datasetSize) {

--- a/widget/IntersectionBetweenModelErrors.tsx
+++ b/widget/IntersectionBetweenModelErrors.tsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom";
 import * as d3 from "d3";
 import { bisect } from "./optimization.tsx";
 import { InfoTooltip } from "./InfoTooltip.tsx";
-import VennLegend from "./VennLegend.tsx";
+import { VennLegend } from "./VennLegend.tsx";
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 
 function calculateCircleRadiiAndDistance(a, b, ab, datasetSize) {

--- a/widget/IntersectionBetweenModelErrors.tsx
+++ b/widget/IntersectionBetweenModelErrors.tsx
@@ -106,12 +106,13 @@ export function getRegionFill(regionName, regionSelected) {
 
 type IntersectionBetweenModelErrorsState = {
   selectedDataPoint: any,
-  selectedRegion: any,
 }
 
 type IntersectionBetweenModelErrorsProps = {
   selectedDataPoint: any,
-  filterByInstanceIds: any
+  filterByInstanceIds: any,
+  setSelectedRegion: any,
+  selectedRegion: any
 }
 
 class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelErrorsProps, IntersectionBetweenModelErrorsState> {
@@ -120,7 +121,6 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
 
     this.state = {
       selectedDataPoint: this.props.selectedDataPoint,
-      selectedRegion: null,
     };
 
     this.node = React.createRef<HTMLDivElement>();
@@ -156,11 +156,9 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
       this.props.filterByInstanceIds(this.regress);
     } else {
       console.log("invalid regionName " + (regionName ?? "null"));
+      return;
     }
-
-    this.setState({
-      selectedRegion: regionName,
-    });
+    this.props.setSelectedRegion(regionName);
   }
 
   createVennDiagramPlot() {
@@ -292,7 +290,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           path.attr("d", intersectionPath)
             .attr("stroke", "black")
             .attr("stroke-width", "1px")
-            .attr("fill", getRegionFill("intersection", _this.state.selectedRegion))
+            .attr("fill", getRegionFill("intersection", _this.props.selectedRegion))
               .on("mouseover", function() {
                 tooltip.text(`${intersectionSize} (${(intersectionProportion * 100).toFixed(3)}%)`)
                   .style("opacity", 0.8);
@@ -315,7 +313,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           rPath.attr("d", regressPath)
             .attr("stroke", "black")
             .attr("stroke-width", "1px")
-            .attr("fill", getRegionFill("regress", _this.state.selectedRegion))
+            .attr("fill", getRegionFill("regress", _this.props.selectedRegion))
             .on("mouseover", function() {
               tooltip.text(`${regressSize} (${(regressProportion * 100).toFixed(3)}%)`)
                 .style("opacity", 0.8);
@@ -338,7 +336,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           pPath.attr("d", progressPath)
             .attr("stroke", "black")
             .attr("stroke-width", "1px")
-            .attr("fill", getRegionFill("progress", _this.state.selectedRegion))
+            .attr("fill", getRegionFill("progress", _this.props.selectedRegion))
             .on("mouseover", function() {
               tooltip.text(`${progressSize} (${(progressProportion * 100).toFixed(3)}%)`)
                 .style("opacity", 0.8);
@@ -373,7 +371,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
                   "translate(" +
                   xCenter + "," +
                   yCenter + ")")
-              .attr("fill", getRegionFill("intersection", _this.state.selectedRegion))
+              .attr("fill", getRegionFill("intersection", _this.props.selectedRegion))
               .attr("stroke", "black")
               .attr("stroke-width", "1px")
               .on("mouseover", function() {
@@ -404,7 +402,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
                   "translate(" +
                   xCenter2 + "," +
                   yCenter + ")")
-              .attr("fill", getRegionFill("intersection", _this.state.selectedRegion))
+              .attr("fill", getRegionFill("intersection", _this.props.selectedRegion))
               .attr("stroke", "black")
               .attr("stroke-width", "1px")
               .on("mouseover", function() {
@@ -435,7 +433,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           pPath.attr("d", progressPath)
             .attr("stroke", "black")
             .attr("stroke-width", "1px")
-            .attr("fill", getRegionFill("progress", _this.state.selectedRegion))
+            .attr("fill", getRegionFill("progress", _this.props.selectedRegion))
             .on("mouseover", function() {
               tooltip.text(`${progressSize} (${(progressProportion * 100).toFixed(3)}%)`)
                 .style("opacity", 0.8);
@@ -465,7 +463,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
                   "translate(" +
                   xCenter2 + "," +
                   yCenter + ")")
-              .attr("fill", getRegionFill("intersection", _this.state.selectedRegion))
+              .attr("fill", getRegionFill("intersection", _this.props.selectedRegion))
               .attr("stroke", "black")
               .attr("stroke-width", "1px")
               .on("mouseover", function() {
@@ -496,7 +494,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           rPath.attr("d", regressPath)
             .attr("stroke", "black")
             .attr("stroke-width", "1px")
-            .attr("fill", getRegionFill("regress", _this.state.selectedRegion))
+            .attr("fill", getRegionFill("regress", _this.props.selectedRegion))
             .on("mouseover", function() {
               tooltip.text(`${regressSize} (${(regressProportion * 100).toFixed(3)}%)`)
                 .style("opacity", 0.8);
@@ -528,7 +526,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
                   "translate(" +
                   xCenter + "," +
                   yCenter + ")")
-              .attr("fill", getRegionFill("progress", _this.state.selectedRegion))
+              .attr("fill", getRegionFill("progress", _this.props.selectedRegion))
               .attr("stroke", "black")
               .attr("stroke-width", "1px")
               .on("mouseover", function() {
@@ -554,7 +552,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
                   "translate(" +
                   xCenter2 + "," +
                   yCenter + ")")
-              .attr("fill", getRegionFill("regress", _this.state.selectedRegion))
+              .attr("fill", getRegionFill("regress", _this.props.selectedRegion))
               .attr("stroke", "black")
               .attr("stroke-width", "1px")
               .on("mouseover", function() {
@@ -588,7 +586,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           Intersection Between Model Errors
           <InfoTooltip direction={DirectionalHint.topCenter} message={diagramInfo}/>
         </div>
-        <VennLegend selectedRegion={this.state.selectedRegion} setSelectedRegion={this.setSelectedRegion}/>
+        <VennLegend selectedRegion={this.props.selectedRegion} setSelectedRegion={this.setSelectedRegion}/>
         <div className="tooltip" id="venntooltip" />
       </div>
     );

--- a/widget/IntersectionBetweenModelErrors.tsx
+++ b/widget/IntersectionBetweenModelErrors.tsx
@@ -181,7 +181,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
     var body = d3.select(this.node.current);
 
     var margin = { top: 5, right: 15, bottom: 50, left: 55 }
-    var h = 250 - margin.top - margin.bottom
+    var h = 220 - margin.top - margin.bottom
     var w = 320 - margin.left - margin.right
 
     var tooltip = d3.select("#venntooltip");
@@ -627,7 +627,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
           </div>
           <div id="commonerror-container" className={getBlockClass("intersection")} onClick={() => _this.setSelectedRegion("intersection")}>
             <div id="commonerror" className="venn-legend-color-box" style={{background: _this.state.intersectionFill}}/>
-            Intersection
+            Common
             <InfoTooltip direction={DirectionalHint.topCenter} message={intersectionInfo}/>
           </div>
         </div> : null }

--- a/widget/IntersectionBetweenModelErrors.tsx
+++ b/widget/IntersectionBetweenModelErrors.tsx
@@ -5,7 +5,8 @@ import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import * as d3 from "d3";
 import { bisect } from "./optimization.tsx";
-
+import { InfoTooltip } from "./InfoTooltip.tsx"
+import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 
 function calculateCircleRadiiAndDistance(a, b, ab, datasetSize) {
   let aProportion = a / datasetSize;
@@ -131,7 +132,7 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
     var _this = this;
     var body = d3.select(this.node.current);
 
-    var margin = { top: 15, right: 15, bottom: 50, left: 55 }
+    var margin = { top: 5, right: 15, bottom: 50, left: 55 }
     var h = 250 - margin.top - margin.bottom
     var w = 320 - margin.left - margin.right
 
@@ -144,18 +145,14 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
         .attr('height',h + margin.top + margin.bottom)
         .attr('width',w + margin.left + margin.right)
       .append('g')
-        .attr('transform',`translate(55,${margin.top + 15})`)
+        .attr('transform',`translate(55,${margin.top})`)
 
     svg.append('text')
       .attr('id','xAxisLabel')
       .attr('y', -20)
       .attr('x', 200)
       .attr('dy','.71em')
-      .style('text-anchor','end')
-      .text("Intersection Between Model Errors")
-      .attr("font-family", "sans-serif")
-      .attr("font-size", "10px")
-      .attr("fill", "black");
+      .style('text-anchor','end');
 
     svg.append("rect")
       .attr("x", 0)
@@ -791,8 +788,13 @@ class IntersectionBetweenModelErrors extends Component<IntersectionBetweenModelE
   }
 
   render() {
+    const message = "Displays the newly trained model’s error counts and percentages in relation to those of the previous model.";
     return (
       <div className="plot plot-venn" ref={this.node} id="venndiagramplot">
+        <div className="plot-title-row">
+          Intersection Between Model Errors
+          <InfoTooltip direction={DirectionalHint.topCenter} message={message}/>
+        </div>
         <div className="tooltip" id="venntooltip" />
       </div>
     );

--- a/widget/MainContainer.tsx
+++ b/widget/MainContainer.tsx
@@ -19,6 +19,8 @@ import {
   toggleNewError,
   toggleStrictImitation,
   selectDataPoint,
+  setSelectedClass,
+  setSelectedRegion,
   getTrainingAndTestingData,
   getModelEvaluationData,
   getSweepStatus,
@@ -31,6 +33,10 @@ function Container({
   data,
   sweepStatus,
   selectedDataPoint,
+  selectedClass,
+  selectedRegion,
+  setSelectedClass,
+  setSelectedRegion,
   filterInstances,
   training,
   testing,
@@ -133,8 +139,8 @@ function Container({
             <SelectedModelDetails btc={selectedDataPoint.btc} bec={selectedDataPoint.bec} h1Performance={data.h1_performance} h2Performance={selectedDataPoint.h2_performance} performanceMetric={data.performance_metric} lambdaC={selectedDataPoint.lambda_c} />
             : null}
           <div className="row">
-            <IntersectionBetweenModelErrors selectedDataPoint={selectedDataPoint} filterByInstanceIds={filterByInstanceIds}/>
-            <IncompatiblePointDistribution selectedDataPoint={selectedDataPoint} filterByInstanceIds={filterByInstanceIds} />
+            <IntersectionBetweenModelErrors selectedDataPoint={selectedDataPoint} setSelectedRegion={setSelectedRegion} selectedRegion={selectedRegion} filterByInstanceIds={filterByInstanceIds}/>
+            <IncompatiblePointDistribution selectedDataPoint={selectedDataPoint} setSelectedClass={setSelectedClass} selectedClass={selectedClass} filterByInstanceIds={filterByInstanceIds} />
           </div>
           <div className="row">
             <ErrorInstancesTable selectedDataPoint={selectedDataPoint} filterInstances={filterInstances} />
@@ -148,6 +154,8 @@ function mapStateToProps (state) {
     data: state.data,
     sweepStatus: state.sweepStatus,
     selectedDataPoint: state.selectedDataPoint,
+    selectedClass: state.selectedClass,
+    selectedRegion: state.selectedRegion,
     filterInstances: state.filterInstances,
     training: state.training,
     testing: state.testing,
@@ -165,6 +173,8 @@ function mapDispatchToProps (dispatch) {
     toggleNewError: toggleNewError,
     toggleStrictImitation: toggleStrictImitation,
     selectDataPoint: selectDataPoint,
+    setSelectedClass: setSelectedClass,
+    setSelectedRegion: setSelectedRegion,
     getTrainingAndTestingData: getTrainingAndTestingData,
     getModelEvaluationData: getModelEvaluationData,
     getSweepStatus: getSweepStatus,

--- a/widget/PerformanceCompatibility.tsx
+++ b/widget/PerformanceCompatibility.tsx
@@ -4,7 +4,8 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import * as d3 from "d3";
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { InfoTooltip } from "./InfoTooltip.tsx"
+import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
 
 
 type PerformanceCompatibilityState = {
@@ -30,6 +31,7 @@ type PerformanceCompatibilityProps = {
   selectDataPoint: (d: any) => void,
   getModelEvaluationData: (evaluationId: number) => void
 }
+
 
 class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, PerformanceCompatibilityState> {
   constructor(props) {
@@ -74,7 +76,7 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
     var body = d3.select(this.node.current);
     var data = this.state.data;
 
-    var margin = { top: 15, right: 15, bottom: 50, left: 55 }
+    var margin = { top: 15, right: 15, bottom: 20, left: 55 }
     var h = 250 - margin.top - margin.bottom
     var w = 320 - margin.left - margin.right
 
@@ -129,7 +131,7 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
 
     // SVG
     d3.select(`#${this.props.compatibilityScoreType}`).remove();
-    var svg = body.append('svg')
+    var svg = body.insert('svg', '.plot-title-row')
         .attr('id', this.props.compatibilityScoreType)
         .attr('height',h + margin.top + margin.bottom)
         .attr('width',w + margin.left + margin.right)
@@ -159,7 +161,6 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
         .attr('x',w/2)
         .attr('dy','.71em')
         .style('text-anchor','end')
-        .text(this.props.compatibilityScoreType.toUpperCase())
         .attr("font-family", "sans-serif")
         .attr("font-size", "20px")
         .attr("fill", "black");
@@ -263,19 +264,30 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
     drawCircles();
   }
 
+
   render() {
     let classes = `plot plot-${this.props.compatibilityScoreType}`;
+    let title = this.props.compatibilityScoreType.toUpperCase();
+    let message = "UNDEFINED";
+
+    if (title == "BTC") {
+      message = "Backward Trust Compatibility (BTC) describes the percentage of trust preserved after an update."
+    } else if (title == "BEC") {
+      message = "Backward Error Compatibility (BEC) captures the probability that a mistake made by the newly trained model is not new.​"
+    }
+
     return (
       <React.Fragment>
         <div className={classes} ref={this.node} id={`scatterplot-${this.props.compatibilityScoreType}`}>
           <div className="tooltip" id={`lambdactooltip-${this.props.compatibilityScoreType}`} />
-          <div className="chart-title-row">
-            <div>BTC</div>
-            <IconButton iconProps={{ iconName: 'Info' }} title="info" ariaLabel="info" />
+          <div className="plot-title-row">
+            {title}
+            <InfoTooltip message={message} direction={DirectionalHint.bottomCenter} />
           </div>
         </div>
       </React.Fragment>
     );
   }
+
 }
 export default PerformanceCompatibility;

--- a/widget/PerformanceCompatibility.tsx
+++ b/widget/PerformanceCompatibility.tsx
@@ -4,6 +4,7 @@
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import * as d3 from "d3";
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
 
 
 type PerformanceCompatibilityState = {
@@ -265,9 +266,15 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
   render() {
     let classes = `plot plot-${this.props.compatibilityScoreType}`;
     return (
-      <div className={classes} ref={this.node} id={`scatterplot-${this.props.compatibilityScoreType}`}>
-        <div className="tooltip" id={`lambdactooltip-${this.props.compatibilityScoreType}`} />
-      </div>
+      <React.Fragment>
+        <div className={classes} ref={this.node} id={`scatterplot-${this.props.compatibilityScoreType}`}>
+          <div className="tooltip" id={`lambdactooltip-${this.props.compatibilityScoreType}`} />
+          <div className="chart-title-row">
+            <div>BTC</div>
+            <IconButton iconProps={{ iconName: 'Info' }} title="info" ariaLabel="info" />
+          </div>
+        </div>
+      </React.Fragment>
     );
   }
 }

--- a/widget/VennLegend.tsx
+++ b/widget/VennLegend.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import React, { FunctionComponent } from "react";
+import ReactDOM from "react-dom";
+import * as d3 from "d3";
+import { bisect } from "./optimization.tsx";
+import { InfoTooltip } from "./InfoTooltip.tsx"
+import { getRegionFill } from "./IntersectionBetweenModelErrors.tsx";
+import { DirectionalHint } from 'office-ui-fabric-react/lib/Tooltip';
+
+type VennLegendProps = {
+  selectedRegion: any
+  setSelectedRegion: Function
+}
+
+export const VennLegend: FunctionComponent<VennLegendProps> = ({ selectedRegion, setSelectedRegion }) => {
+  const progressInfo = "Indicates errors made by the previous model that the newly trained model does not make.​";
+  const regressInfo = "Indicates errors made by the newly trained model that the previous model did not make.​";
+  const intersectionInfo = "Indicates errors made by both the previous and newly trained models.​";
+
+  function getBlockClass(regionName: string) : string {
+    if (selectedRegion == regionName) {
+      return "venn-legend-row-block-selected";
+    } else {
+      return "venn-legend-row-block";
+    }
+  }
+
+  return (
+    <div className="venn-legend-row">
+      <div id="progress-container" className={getBlockClass("progress")} onClick={() => setSelectedRegion("progress")}>
+        <div id="progress" className="venn-legend-color-box" style={{ background: getRegionFill("progress", selectedRegion) }} />
+        Progress
+        <InfoTooltip direction={DirectionalHint.topCenter} message={progressInfo} />
+      </div>
+      <div id="commonerror-container" className={getBlockClass("intersection")} onClick={() => setSelectedRegion("intersection")}>
+        <div id="commonerror" className="venn-legend-color-box" style={{ background: getRegionFill("intersection", selectedRegion) }} />
+        Common
+        <InfoTooltip direction={DirectionalHint.topCenter} message={intersectionInfo} />
+      </div>
+      <div id="regress-container" className={getBlockClass("regress")} onClick={() => setSelectedRegion("regress")}>
+        <div id="regress" className="venn-legend-color-box" style={{ background: getRegionFill("regress", selectedRegion) }} />
+        Regress
+        <InfoTooltip direction={DirectionalHint.topCenter} message={regressInfo} />
+      </div>
+    </div>
+  )
+};

--- a/widget/VennLegend.tsx
+++ b/widget/VennLegend.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { FunctionComponent } from "react";
+import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import * as d3 from "d3";
 import { bisect } from "./optimization.tsx";
@@ -14,36 +14,41 @@ type VennLegendProps = {
   setSelectedRegion: Function
 }
 
-export const VennLegend: FunctionComponent<VennLegendProps> = ({ selectedRegion, setSelectedRegion }) => {
-  const progressInfo = "Indicates errors made by the previous model that the newly trained model does not make.​";
-  const regressInfo = "Indicates errors made by the newly trained model that the previous model did not make.​";
-  const intersectionInfo = "Indicates errors made by both the previous and newly trained models.​";
+class VennLegend extends Component<VennLegendProps> {
+  render() {
+    const progressInfo = "Indicates errors made by the previous model that the newly trained model does not make.​";
+    const regressInfo = "Indicates errors made by the newly trained model that the previous model did not make.​";
+    const intersectionInfo = "Indicates errors made by both the previous and newly trained models.​";
+    const selectedRegion = this.props.selectedRegion;
 
-  function getBlockClass(regionName: string) : string {
-    if (selectedRegion == regionName) {
-      return "venn-legend-row-block-selected";
-    } else {
-      return "venn-legend-row-block";
+    function getBlockClass(regionName: string) : string {
+      if (selectedRegion == regionName) {
+        return "venn-legend-row-block-selected";
+      } else {
+        return "venn-legend-row-block";
+      }
     }
-  }
 
-  return (
-    <div className="venn-legend-row">
-      <div id="progress-container" className={getBlockClass("progress")} onClick={() => setSelectedRegion("progress")}>
-        <div id="progress" className="venn-legend-color-box" style={{ background: getRegionFill("progress", selectedRegion) }} />
-        Progress
-        <InfoTooltip direction={DirectionalHint.topCenter} message={progressInfo} />
+    return (
+      <div className="venn-legend-row">
+        <div id="progress-container" className={getBlockClass("progress")} onClick={() => this.props.setSelectedRegion("progress")}>
+          <div id="progress" className="venn-legend-color-box" style={{ background: getRegionFill("progress", selectedRegion) }} />
+          Progress
+          <InfoTooltip direction={DirectionalHint.topCenter} message={progressInfo} />
+        </div>
+        <div id="commonerror-container" className={getBlockClass("intersection")} onClick={() => this.props.setSelectedRegion("intersection")}>
+          <div id="commonerror" className="venn-legend-color-box" style={{ background: getRegionFill("intersection", selectedRegion) }} />
+          Common
+          <InfoTooltip direction={DirectionalHint.topCenter} message={intersectionInfo} />
+        </div>
+        <div id="regress-container" className={getBlockClass("regress")} onClick={() => this.props.setSelectedRegion("regress")}>
+          <div id="regress" className="venn-legend-color-box" style={{ background: getRegionFill("regress", selectedRegion) }} />
+          Regress
+          <InfoTooltip direction={DirectionalHint.topCenter} message={regressInfo} />
+        </div>
       </div>
-      <div id="commonerror-container" className={getBlockClass("intersection")} onClick={() => setSelectedRegion("intersection")}>
-        <div id="commonerror" className="venn-legend-color-box" style={{ background: getRegionFill("intersection", selectedRegion) }} />
-        Common
-        <InfoTooltip direction={DirectionalHint.topCenter} message={intersectionInfo} />
-      </div>
-      <div id="regress-container" className={getBlockClass("regress")} onClick={() => setSelectedRegion("regress")}>
-        <div id="regress" className="venn-legend-color-box" style={{ background: getRegionFill("regress", selectedRegion) }} />
-        Regress
-        <InfoTooltip direction={DirectionalHint.topCenter} message={regressInfo} />
-      </div>
-    </div>
-  )
-};
+    )
+  }
+}
+
+export default VennLegend;

--- a/widget/VennLegend.tsx
+++ b/widget/VennLegend.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import React, { Component } from "react";
+import React, { FunctionComponent } from "react";
 import ReactDOM from "react-dom";
 import * as d3 from "d3";
 import { bisect } from "./optimization.tsx";
@@ -14,41 +14,36 @@ type VennLegendProps = {
   setSelectedRegion: Function
 }
 
-class VennLegend extends Component<VennLegendProps> {
-  render() {
-    const progressInfo = "Indicates errors made by the previous model that the newly trained model does not make.​";
-    const regressInfo = "Indicates errors made by the newly trained model that the previous model did not make.​";
-    const intersectionInfo = "Indicates errors made by both the previous and newly trained models.​";
-    const selectedRegion = this.props.selectedRegion;
+export const VennLegend: FunctionComponent<VennLegendProps> = ({ selectedRegion, setSelectedRegion }) => {
+  const progressInfo = "Indicates errors made by the previous model that the newly trained model does not make.​";
+  const regressInfo = "Indicates errors made by the newly trained model that the previous model did not make.​";
+  const intersectionInfo = "Indicates errors made by both the previous and newly trained models.​";
 
-    function getBlockClass(regionName: string) : string {
-      if (selectedRegion == regionName) {
-        return "venn-legend-row-block-selected";
-      } else {
-        return "venn-legend-row-block";
-      }
+  function getBlockClass(regionName: string) : string {
+    if (selectedRegion == regionName) {
+      return "venn-legend-row-block-selected";
+    } else {
+      return "venn-legend-row-block";
     }
-
-    return (
-      <div className="venn-legend-row">
-        <div id="progress-container" className={getBlockClass("progress")} onClick={() => this.props.setSelectedRegion("progress")}>
-          <div id="progress" className="venn-legend-color-box" style={{ background: getRegionFill("progress", selectedRegion) }} />
-          Progress
-          <InfoTooltip direction={DirectionalHint.topCenter} message={progressInfo} />
-        </div>
-        <div id="commonerror-container" className={getBlockClass("intersection")} onClick={() => this.props.setSelectedRegion("intersection")}>
-          <div id="commonerror" className="venn-legend-color-box" style={{ background: getRegionFill("intersection", selectedRegion) }} />
-          Common
-          <InfoTooltip direction={DirectionalHint.topCenter} message={intersectionInfo} />
-        </div>
-        <div id="regress-container" className={getBlockClass("regress")} onClick={() => this.props.setSelectedRegion("regress")}>
-          <div id="regress" className="venn-legend-color-box" style={{ background: getRegionFill("regress", selectedRegion) }} />
-          Regress
-          <InfoTooltip direction={DirectionalHint.topCenter} message={regressInfo} />
-        </div>
-      </div>
-    )
   }
-}
 
-export default VennLegend;
+  return (
+    <div className="venn-legend-row">
+      <div id="progress-container" className={getBlockClass("progress")} onClick={() => setSelectedRegion("progress")}>
+        <div id="progress" className="venn-legend-color-box" style={{ background: getRegionFill("progress", selectedRegion) }} />
+        Progress
+        <InfoTooltip direction={DirectionalHint.topCenter} message={progressInfo} />
+      </div>
+      <div id="commonerror-container" className={getBlockClass("intersection")} onClick={() => setSelectedRegion("intersection")}>
+        <div id="commonerror" className="venn-legend-color-box" style={{ background: getRegionFill("intersection", selectedRegion) }} />
+        Common
+        <InfoTooltip direction={DirectionalHint.topCenter} message={intersectionInfo} />
+      </div>
+      <div id="regress-container" className={getBlockClass("regress")} onClick={() => setSelectedRegion("regress")}>
+        <div id="regress" className="venn-legend-color-box" style={{ background: getRegionFill("regress", selectedRegion) }} />
+        Regress
+        <InfoTooltip direction={DirectionalHint.topCenter} message={regressInfo} />
+      </div>
+    </div>
+  )
+};

--- a/widget/actions.ts
+++ b/widget/actions.ts
@@ -35,6 +35,20 @@ function selectDataPoint(dataPoint) {
   }
 }
 
+function setSelectedClass(selectedClass) {
+  return {
+    type: "SET_SELECTED_CLASS",
+    selectedClass: selectedClass
+  }
+}
+
+function setSelectedRegion(selectedRegion) {
+  return {
+    type: "SET_SELECTED_REGION",
+    selectedRegion: selectedRegion
+  }
+}
+
 function requestTrainingAndTestingData() {
   return {
     type: "REQUEST_TRAINING_AND_TESTING_DATA"
@@ -136,6 +150,8 @@ export {
   toggleNewError,
   toggleStrictImitation,
   selectDataPoint,
+  setSelectedClass,
+  setSelectedRegion,
   getTrainingAndTestingData,
   getModelEvaluationData,
   getSweepStatus,

--- a/widget/index.tsx
+++ b/widget/index.tsx
@@ -9,10 +9,13 @@ import rootReducer from './reducers.ts'
 import MainContainer from "./MainContainer.tsx";
 import { createLogger } from 'redux-logger';
 import thunkMiddleware from 'redux-thunk';
+import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
+
 import "./widget.css";
 
 const loggerMiddleware = createLogger()
 const store = createStore(rootReducer, applyMiddleware(thunkMiddleware, loggerMiddleware));
+initializeIcons();
 
 ReactDOM.render(
   <Provider store={store}>

--- a/widget/reducers.ts
+++ b/widget/reducers.ts
@@ -5,6 +5,8 @@ const rawInitialState = {
    data: null,
    sweepStatus: null,
    selectedDataPoint: null,
+   selectedRegion: null,
+   selectedClass: null,
    filterInstances: null,
    training: true,
    testing: true,
@@ -32,6 +34,12 @@ function rootReducer(state = initialState, action) {
 
         case "SELECT_DATA_POINT":
           return Object.assign({}, state, {filterInstances: null, selectedDataPoint: action.dataPoint});
+
+        case "SET_SELECTED_REGION":
+          return Object.assign({}, state, {selectedClass: null, selectedRegion: action.selectedRegion});
+
+        case "SET_SELECTED_CLASS":
+          return Object.assign({}, state, {selectedRegion: null, selectedClass: action.selectedClass});
 
         case "REQUEST_TRAINING_AND_TESTING_DATA":
           return Object.assign({}, state, {filterInstances: null, loading: true});

--- a/widget/widget.css
+++ b/widget/widget.css
@@ -226,3 +226,11 @@ label {
   stroke-width: 2;
   stroke: rgb(0,0,0);
 }
+
+.chart-title-row {
+  display: flex;
+  background-color: white;
+  flex-direction: row;
+  justify-content: center;
+  margin-top: 5px;
+}

--- a/widget/widget.css
+++ b/widget/widget.css
@@ -83,6 +83,8 @@ label {
   font-family: sans-serif;
   font-size: 10px;
   padding-left: 40px;
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .page-button-row {
@@ -111,6 +113,7 @@ label {
   justify-content: center;
   align-items: center;
   font-size: 10px;
+  padding-left: 37px;
 }
 
 .venn-legend-row-block {

--- a/widget/widget.css
+++ b/widget/widget.css
@@ -74,6 +74,17 @@ label {
   padding-bottom: 10px;
 }
 
+.plot-title-row {
+  display: flex;
+  background-color: white;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-family: sans-serif;
+  font-size: 10px;
+  padding-left: 40px;
+}
+
 .page-button-row {
   display: flex;
   flex-direction: row;
@@ -225,12 +236,4 @@ label {
 .highlighted-bar {
   stroke-width: 2;
   stroke: rgb(0,0,0);
-}
-
-.chart-title-row {
-  display: flex;
-  background-color: white;
-  flex-direction: row;
-  justify-content: center;
-  margin-top: 5px;
 }

--- a/widget/widget.css
+++ b/widget/widget.css
@@ -65,6 +65,7 @@ label {
   padding-top: 20px;
   padding-bottom: 39px;
   vertical-align: top;
+  line-height: 20px;
 }
 
 .plot-distribution {
@@ -72,6 +73,7 @@ label {
   padding-right:20px;
   padding-top: 20px;
   padding-bottom: 10px;
+  line-height: 20px;
 }
 
 .plot-title-row {

--- a/widget/widget.css
+++ b/widget/widget.css
@@ -103,6 +103,47 @@ label {
   border: 1px solid black;
 }
 
+.venn-legend-row {
+  display: flex;
+  background-color: white;
+  flex-direction: row;
+  font-family: sans-serif;
+  justify-content: center;
+  align-items: center;
+  font-size: 10px;
+}
+
+.venn-legend-row-block {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 5px;
+}
+
+.venn-legend-row-block-selected {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  border: 2px solid rgb(200,200,200);
+  padding: 3px;
+}
+
+.venn-legend-row-block:hover {
+  border: 2px solid black;
+  padding: 3px;
+}
+
+.venn-legend-row-block-selected:hover {
+  border: 2px solid black;
+  padding: 3px;
+}
+
+.venn-legend-color-box {
+  height: 10px;
+  width: 10px;
+  margin-right: 5px;
+}
+
 .tooltip {
   background-color: black;
   color: white;


### PR DESCRIPTION
Adds help tooltips to the charts in the widget.

Currently, the tooltips for the venn diagram legend have still not been implemented. I'm planning to wait until clickable legend https://github.com/microsoft/BackwardCompatibilityML/pull/78 is merged. The legend will need to be extracted from the d3 graph so I can add tooltips there.

For issue https://github.com/microsoft/BackwardCompatibilityML/issues/39

![image](https://user-images.githubusercontent.com/1587757/99604549-96777880-29ba-11eb-869a-68c3fd359a3c.png)


