### PR TITLE
Implement a Backward Compatibility New Error Model for training Tensorflow models using the BC New Error Loss

### DIFF
--- a/backwardcompatibilityml/tensorflow/__init__.py
+++ b/backwardcompatibilityml/tensorflow/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.

--- a/backwardcompatibilityml/tensorflow/helpers.py
+++ b/backwardcompatibilityml/tensorflow/helpers.py
@@ -1,0 +1,45 @@
+import tensorflow.compat.v2 as tf
+
+
+def bc_fit(h2, training_set=None, testing_set=None, epochs=None, bc_loss=None, optimizer=None):
+    @tf.function
+    def compatibility_train_step(x_batch_train, y_batch_train, bc_loss, optimizer, h2):
+        # Open a GradientTape to record the operations run
+        # during the forward pass, which enables auto-differentiation.
+        with tf.GradientTape() as tape:
+
+            # Run the forward pass of the layer.
+            # The operations that the layer applies
+            # to its inputs are going to be recorded
+            # on the GradientTape.
+            # Compute the loss value for this minibatch.
+            loss_value = bc_loss(x_batch_train, y_batch_train)
+
+        # Use the gradient tape to automatically retrieve
+        # the gradients of the trainable variables with respect to the loss.
+        grads = tape.gradient(loss_value, h2.trainable_weights)
+
+        # Run one step of gradient descent by updating
+        # the value of the variables to minimize the loss.
+        optimizer.apply_gradients(zip(grads, h2.trainable_weights))
+
+        return loss_value
+
+    for epoch in range(epochs):
+        print(f"Epoch {epoch + 1}/{epochs}")
+        # Iterate over the batches of the dataset.
+        for step, (x_batch_train, y_batch_train) in enumerate(training_set):
+
+            loss_value = compatibility_train_step(
+                x_batch_train, y_batch_train, bc_loss, optimizer, h2)
+
+            # Log every 10 batches.
+            if step % 10 == 0:
+                print("=", end="")
+
+        print(
+            " Training loss: %.4f"
+            % (float(loss_value),)
+        )
+
+    print("Training done.")

--- a/backwardcompatibilityml/tensorflow/loss/new_error.py
+++ b/backwardcompatibilityml/tensorflow/loss/new_error.py
@@ -1,0 +1,29 @@
+import tensorflow.compat.v2 as tf
+
+
+class BCCrossEntropyLoss(object):
+
+    def __init__(self, h1, h2, lambda_c):
+        self.h1 = h1
+        self.h2 = h2
+        self.lambda_c = lambda_c
+        self.__name__ = "BCCrossEntropyLoss"
+        self.cce_loss = tf.keras.losses.SparseCategoricalCrossentropy(
+            reduction=tf.keras.losses.Reduction.SUM)
+
+    def dissonance(self, h2_output, target_labels):
+        cross_entropy_loss = self.cce_loss(target_labels, h2_output)
+        return cross_entropy_loss
+
+    def __call__(self, x, y):
+        h1_output = tf.argmax(self.h1(x), axis=1)
+        h2_output = self.h2(x)
+        h1_diff = h1_output - y
+        h1_correct = (h1_diff == 0)
+        _, x_support = tf.dynamic_partition(x, tf.dtypes.cast(h1_correct, tf.int32), 2)
+        _, y_support = tf.dynamic_partition(y, tf.dtypes.cast(h1_correct, tf.int32), 2)
+        h2_support_output = self.h2(x_support)
+        dissonance = self.dissonance(h2_support_output, y_support)
+        new_error_loss = self.cce_loss(y, h2_output) + self.lambda_c * dissonance
+
+        return tf.reduce_sum(new_error_loss)

--- a/backwardcompatibilityml/tensorflow/models.py
+++ b/backwardcompatibilityml/tensorflow/models.py
@@ -28,8 +28,8 @@ class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
         specified by the user to calculate the loss on a subset
         of the target.
         """
-        cross_entropy_loss = loss(target_labels, h2_output)
-        return cross_entropy_loss
+        calculated_loss = loss(target_labels, h2_output)
+        return calculated_loss
 
     def loss_func(self, x, y, loss=None):
         """

--- a/backwardcompatibilityml/tensorflow/models.py
+++ b/backwardcompatibilityml/tensorflow/models.py
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import tensorflow.compat.v2 as tf
+
+
+class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
+
+    def __init__(self, *args, h1=None, lambda_c=None, **kwargs):
+        """
+        Args:
+          h1: An existing tensorflow model that has been pre-trained,
+            and which we want to be compatible with.
+        lambda_c: A floating point value between 0.0 and 1.0 that is
+          used as a regularization parameter to weight how much the
+          dissonance is used to penalize the loss while training.
+        """
+        super(BCNewErrorCompatibilityModel, self).__init__(*args)
+        self.h1 = h1
+        self.lambda_c = lambda_c
+
+    def dissonance(self, h2_output, target_labels, loss):
+        """
+        The dissonance function, which uses the loss function
+        specified by the user to calculate the loss on a subset
+        of the target.
+        """
+        cross_entropy_loss = loss(target_labels, h2_output)
+        return cross_entropy_loss
+
+    def loss_func(self, x, y, loss=None):
+        """
+        Backward compatibility loss function to be used by the model
+        """
+        if loss is None:
+            loss = tf.keras.losses.SparseCategoricalCrossentropy(
+                reduction=tf.keras.losses.Reduction.SUM)
+        h1_output = tf.argmax(self.h1(x), axis=1)
+        h2_output = self(x)
+        h1_diff = h1_output - y
+
+        # Here we determine which datapoints were correctly labeled by h1
+        h1_correct = (h1_diff == 0)
+
+        # Here we pull those datapoints which were correctly labeled by h1
+        _, x_support = tf.dynamic_partition(x, tf.dtypes.cast(h1_correct, tf.int32), 2)
+
+        # Here we pull the ground truth labels for those datapoints which were
+        # correctly labeled by h1.
+        _, y_support = tf.dynamic_partition(y, tf.dtypes.cast(h1_correct, tf.int32), 2)
+
+        # Here we pull those outputs of h2, on datapoints which were correctly labeled
+        # by h1. And use these to calculate the new error dissonance.
+        _, h2_support_output = tf.dynamic_partition(h2_output, tf.dtypes.cast(h1_correct, tf.int32), 2)
+        new_error_dissonance = self.dissonance(h2_support_output, y_support, loss)
+
+        # We calculate the new error loss.
+        new_error_loss = loss(y, h2_output) + self.lambda_c * new_error_dissonance
+
+        return tf.reduce_sum(new_error_loss)
+
+    def train_step(self, data):
+        """
+        This is a custom train step which allows us to use to train our model
+        using the `fit()` method, using a non-standard loss funtion.
+        """
+        x, y = data
+
+        with tf.GradientTape() as tape:
+            # Here we compute the loss using the loss function specified
+            # by the user in `compile()`, within the context of our compatibility
+            # loss function.
+            loss = self.loss_func(x, y, loss=self.compiled_loss)
+
+        # Compute gradients
+        gradients = tape.gradient(loss, self.trainable_weights)
+
+        # Update weights
+        self.optimizer.apply_gradients(zip(gradients, self.trainable_weights))
+
+        # Update the metrics.
+        # Metrics are configured in `compile()`.
+        y_pred = self(x, training=False)
+        self.compiled_metrics.update_state(y, y_pred)
+
+        # Return a dict mapping metric names to current value.
+        # Note that it will include the loss (tracked in self.metrics).
+        return {m.name: m.result() for m in self.metrics}

--- a/backwardcompatibilityml/tensorflow/models.py
+++ b/backwardcompatibilityml/tensorflow/models.py
@@ -6,7 +6,7 @@ import tensorflow.compat.v2 as tf
 
 class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
 
-    def __init__(self, *args, h1=None, lambda_c=None, **kwargs):
+    def __init__(self, *args, h1=None, lambda_c=0.0, **kwargs):
         """
         Args:
           h1: An existing tensorflow model that has been pre-trained,
@@ -16,6 +16,9 @@ class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
           dissonance is used to penalize the loss while training.
         """
         super(BCNewErrorCompatibilityModel, self).__init__(*args)
+
+        if h1 is None:
+            raise Exception("The parameter h1 is required.")
         self.h1 = h1
         self.lambda_c = lambda_c
 

--- a/examples/tensorflow-MNIST-generalized.ipynb
+++ b/examples/tensorflow-MNIST-generalized.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow.compat.v2 as tf\n",
+    "import tensorflow_datasets as tfds\n",
+    "import tensorflow.keras.backend as kb\n",
+    "from backwardcompatibilityml import scores\n",
+    "from backwardcompatibilityml.tensorflow import helpers as tf_helpers\n",
+    "import copy\n",
+    "\n",
+    "tf.enable_v2_behavior()\n",
+    "tf.random.set_seed(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(ds_train, ds_test), ds_info = tfds.load(\n",
+    "    'mnist',\n",
+    "    split=['train', 'test'],\n",
+    "    shuffle_files=True,\n",
+    "    as_supervised=True,\n",
+    "    with_info=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize_img(image, label):\n",
+    "  \"\"\"Normalizes images: `uint8` -> `float32`.\"\"\"\n",
+    "  return tf.cast(image, tf.float32) / 255., label\n",
+    "\n",
+    "ds_train = ds_train.map(\n",
+    "    normalize_img, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
+    "ds_train = ds_train.cache()\n",
+    "ds_train = ds_train.shuffle(ds_info.splits['train'].num_examples)\n",
+    "ds_train = ds_train.batch(128)\n",
+    "ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_test = ds_test.map(\n",
+    "    normalize_img, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
+    "ds_test = ds_test.batch(128)\n",
+    "ds_test = ds_test.cache()\n",
+    "ds_test = ds_test.prefetch(tf.data.experimental.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/3\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.3558 - accuracy: 0.9021 - val_loss: 0.1865 - val_accuracy: 0.9458\n",
+      "Epoch 2/3\n",
+      "469/469 [==============================] - 1s 1ms/step - loss: 0.1606 - accuracy: 0.9536 - val_loss: 0.1407 - val_accuracy: 0.9575\n",
+      "Epoch 3/3\n",
+      "469/469 [==============================] - 1s 1ms/step - loss: 0.1157 - accuracy: 0.9668 - val_loss: 0.1060 - val_accuracy: 0.9679\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tensorflow.python.keras.callbacks.History at 0x7fb1cc04c668>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = tf.keras.models.Sequential([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),\n",
+    "  tf.keras.layers.Dense(128,activation='relu'),\n",
+    "  tf.keras.layers.Dense(10, activation='softmax')\n",
+    "])\n",
+    "model.compile(\n",
+    "    loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
+    "    optimizer=tf.keras.optimizers.Adam(0.001),\n",
+    "    metrics=['accuracy'],\n",
+    ")\n",
+    "\n",
+    "model.fit(\n",
+    "    ds_train,\n",
+    "    epochs=3,\n",
+    "    validation_data=ds_test,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BCCrossEntropyLoss(object):\n",
+    "    \n",
+    "    def __init__(self, h1, h2, lambda_c):\n",
+    "        self.h1 = h1\n",
+    "        self.h2 = h2\n",
+    "        self.lambda_c = lambda_c\n",
+    "        self.__name__ = \"BCCrossEntropyLoss\"\n",
+    "        self.cce_loss = tf.keras.losses.SparseCategoricalCrossentropy(\n",
+    "            reduction=tf.keras.losses.Reduction.SUM)\n",
+    "    \n",
+    "    def dissonance(self, h2_output, target_labels):\n",
+    "        cross_entropy_loss = self.cce_loss(target_labels, h2_output)\n",
+    "        return cross_entropy_loss\n",
+    "    \n",
+    "    def __call__(self, x, y):\n",
+    "        h1_output = tf.argmax(self.h1(x), axis=1)\n",
+    "        h2_output = self.h2(x)\n",
+    "        h1_diff = h1_output - y\n",
+    "        h1_correct = (h1_diff == 0)\n",
+    "        _, x_support = tf.dynamic_partition(x, tf.dtypes.cast(h1_correct, tf.int32), 2)\n",
+    "        _, y_support = tf.dynamic_partition(y, tf.dtypes.cast(h1_correct, tf.int32), 2)\n",
+    "        h2_support_output = self.h2(x_support)\n",
+    "        dissonance = self.dissonance(h2_support_output, y_support)\n",
+    "        new_error_loss = self.cce_loss(y, h2_output) + self.lambda_c * dissonance\n",
+    "        \n",
+    "        return tf.reduce_sum(new_error_loss)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_c = 0.9\n",
+    "model.trainable = False\n",
+    "\n",
+    "h2 = tf.keras.models.Sequential([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),\n",
+    "  tf.keras.layers.Dense(128,activation='relu'),\n",
+    "  tf.keras.layers.Dense(10, activation='softmax')\n",
+    "])\n",
+    "\n",
+    "bc_loss = BCCrossEntropyLoss(model, h2, lambda_c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = tf.keras.optimizers.Adam(0.001)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/6\n",
+      "=============================================== Training loss: 25.0517\n",
+      "Epoch 2/6\n",
+      "=============================================== Training loss: 18.5583\n",
+      "Epoch 3/6\n",
+      "=============================================== Training loss: 26.4048\n",
+      "Epoch 4/6\n",
+      "=============================================== Training loss: 14.9898\n",
+      "Epoch 5/6\n",
+      "=============================================== Training loss: 7.7008\n",
+      "Epoch 6/6\n",
+      "=============================================== Training loss: 5.2657\n",
+      "Training done.\n"
+     ]
+    }
+   ],
+   "source": [
+    "tf_helpers.bc_fit(h2, training_set=ds_train, testing_set=ds_test, epochs=6, bc_loss=bc_loss, optimizer=optimizer)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.trainable = False\n",
+    "h2.trainable = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h1_predicted_labels = []\n",
+    "h2_predicted_labels = []\n",
+    "ground_truth_labels = []\n",
+    "for x_batch_test, y_batch_test in ds_test:\n",
+    "    h1_batch_predictions = tf.argmax(model(x_batch_test), axis=1)\n",
+    "    h2_batch_predictions = tf.argmax(h2(x_batch_test), axis=1)\n",
+    "    h1_predicted_labels += h1_batch_predictions.numpy().tolist()\n",
+    "    h2_predicted_labels += h2_batch_predictions.numpy().tolist()\n",
+    "    ground_truth_labels += y_batch_test.numpy().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lambda_c: 0.9\n",
+      "BTC: 0.9932844302097324\n",
+      "BEC: 0.660436137071651\n"
+     ]
+    }
+   ],
+   "source": [
+    "btc = scores.trust_compatibility_score(h1_predicted_labels, h2_predicted_labels, ground_truth_labels)\n",
+    "bec = scores.error_compatibility_score(h1_predicted_labels, h2_predicted_labels, ground_truth_labels)\n",
+    "\n",
+    "print(f\"lambda_c: {lambda_c}\")\n",
+    "print(f\"BTC: {btc}\")\n",
+    "print(f\"BEC: {bec}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/tensorflow-MNIST-generalized.ipynb
+++ b/examples/tensorflow-MNIST-generalized.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,6 +11,7 @@
     "import tensorflow.keras.backend as kb\n",
     "from backwardcompatibilityml import scores\n",
     "from backwardcompatibilityml.tensorflow import helpers as tf_helpers\n",
+    "from backwardcompatibilityml.tensorflow.loss.new_error import BCCrossEntropyLoss\n",
     "import copy\n",
     "\n",
     "tf.enable_v2_behavior()\n",
@@ -19,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -73,20 +74,20 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/3\n",
-      "469/469 [==============================] - 1s 2ms/step - loss: 0.3558 - accuracy: 0.9021 - val_loss: 0.1865 - val_accuracy: 0.9458\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.3566 - accuracy: 0.9004 - val_loss: 0.1871 - val_accuracy: 0.9453\n",
       "Epoch 2/3\n",
-      "469/469 [==============================] - 1s 1ms/step - loss: 0.1606 - accuracy: 0.9536 - val_loss: 0.1407 - val_accuracy: 0.9575\n",
+      "469/469 [==============================] - 1s 1ms/step - loss: 0.1598 - accuracy: 0.9542 - val_loss: 0.1292 - val_accuracy: 0.9629\n",
       "Epoch 3/3\n",
-      "469/469 [==============================] - 1s 1ms/step - loss: 0.1157 - accuracy: 0.9668 - val_loss: 0.1060 - val_accuracy: 0.9679\n"
+      "469/469 [==============================] - 1s 1ms/step - loss: 0.1136 - accuracy: 0.9673 - val_loss: 0.1029 - val_accuracy: 0.9689\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<tensorflow.python.keras.callbacks.History at 0x7fb1cc04c668>"
+       "<tensorflow.python.keras.callbacks.History at 0x7f998c12e8d0>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -112,41 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class BCCrossEntropyLoss(object):\n",
-    "    \n",
-    "    def __init__(self, h1, h2, lambda_c):\n",
-    "        self.h1 = h1\n",
-    "        self.h2 = h2\n",
-    "        self.lambda_c = lambda_c\n",
-    "        self.__name__ = \"BCCrossEntropyLoss\"\n",
-    "        self.cce_loss = tf.keras.losses.SparseCategoricalCrossentropy(\n",
-    "            reduction=tf.keras.losses.Reduction.SUM)\n",
-    "    \n",
-    "    def dissonance(self, h2_output, target_labels):\n",
-    "        cross_entropy_loss = self.cce_loss(target_labels, h2_output)\n",
-    "        return cross_entropy_loss\n",
-    "    \n",
-    "    def __call__(self, x, y):\n",
-    "        h1_output = tf.argmax(self.h1(x), axis=1)\n",
-    "        h2_output = self.h2(x)\n",
-    "        h1_diff = h1_output - y\n",
-    "        h1_correct = (h1_diff == 0)\n",
-    "        _, x_support = tf.dynamic_partition(x, tf.dtypes.cast(h1_correct, tf.int32), 2)\n",
-    "        _, y_support = tf.dynamic_partition(y, tf.dtypes.cast(h1_correct, tf.int32), 2)\n",
-    "        h2_support_output = self.h2(x_support)\n",
-    "        dissonance = self.dissonance(h2_support_output, y_support)\n",
-    "        new_error_loss = self.cce_loss(y, h2_output) + self.lambda_c * dissonance\n",
-    "        \n",
-    "        return tf.reduce_sum(new_error_loss)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -181,17 +148,17 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/6\n",
-      "=============================================== Training loss: 25.0517\n",
+      "=============================================== Training loss: 30.3704\n",
       "Epoch 2/6\n",
-      "=============================================== Training loss: 18.5583\n",
+      "=============================================== Training loss: 11.3028\n",
       "Epoch 3/6\n",
-      "=============================================== Training loss: 26.4048\n",
+      "=============================================== Training loss: 6.8640\n",
       "Epoch 4/6\n",
-      "=============================================== Training loss: 14.9898\n",
+      "=============================================== Training loss: 5.2758\n",
       "Epoch 5/6\n",
-      "=============================================== Training loss: 7.7008\n",
+      "=============================================== Training loss: 8.9757\n",
       "Epoch 6/6\n",
-      "=============================================== Training loss: 5.2657\n",
+      "=============================================== Training loss: 10.8937\n",
       "Training done.\n"
      ]
     }
@@ -202,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -237,8 +204,8 @@
      "output_type": "stream",
      "text": [
       "lambda_c: 0.9\n",
-      "BTC: 0.9932844302097324\n",
-      "BEC: 0.660436137071651\n"
+      "BTC: 0.9922592630818454\n",
+      "BEC: 0.6527331189710611\n"
      ]
     }
    ],

--- a/examples/tensorflow-MNIST.ipynb
+++ b/examples/tensorflow-MNIST.ipynb
@@ -1,0 +1,399 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow.compat.v2 as tf\n",
+    "import tensorflow_datasets as tfds\n",
+    "import tensorflow.keras.backend as kb\n",
+    "from backwardcompatibilityml import scores\n",
+    "from backwardcompatibilityml.tensorflow.models import BCNewErrorCompatibilityModel\n",
+    "\n",
+    "tf.enable_v2_behavior()\n",
+    "tf.random.set_seed(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(ds_train, ds_test), ds_info = tfds.load(\n",
+    "    'mnist',\n",
+    "    split=['train', 'test'],\n",
+    "    shuffle_files=True,\n",
+    "    as_supervised=True,\n",
+    "    with_info=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize_img(image, label):\n",
+    "  \"\"\"Normalizes images: `uint8` -> `float32`.\"\"\"\n",
+    "  return tf.cast(image, tf.float32) / 255., label\n",
+    "\n",
+    "ds_train = ds_train.map(\n",
+    "    normalize_img, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
+    "ds_train = ds_train.cache()\n",
+    "ds_train = ds_train.shuffle(ds_info.splits['train'].num_examples)\n",
+    "ds_train = ds_train.batch(128)\n",
+    "ds_train = ds_train.prefetch(tf.data.experimental.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_test = ds_test.map(\n",
+    "    normalize_img, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
+    "ds_test = ds_test.batch(128)\n",
+    "ds_test = ds_test.cache()\n",
+    "ds_test = ds_test.prefetch(tf.data.experimental.AUTOTUNE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = tf.keras.models.Sequential([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),\n",
+    "  tf.keras.layers.Dense(128,activation='relu'),\n",
+    "  tf.keras.layers.Dense(10, activation='softmax')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/3\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.3602 - accuracy: 0.8992 - val_loss: 0.1841 - val_accuracy: 0.9458\n",
+      "Epoch 2/3\n",
+      "469/469 [==============================] - 1s 1ms/step - loss: 0.1616 - accuracy: 0.9535 - val_loss: 0.1312 - val_accuracy: 0.9606\n",
+      "Epoch 3/3\n",
+      "469/469 [==============================] - 1s 1ms/step - loss: 0.1149 - accuracy: 0.9675 - val_loss: 0.1049 - val_accuracy: 0.9697\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tensorflow.python.keras.callbacks.History at 0x7f2b8c6abf28>"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model.compile(\n",
+    "    loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
+    "    optimizer=tf.keras.optimizers.Adam(0.001),\n",
+    "    metrics=['accuracy'],\n",
+    ")\n",
+    "\n",
+    "model.fit(\n",
+    "    ds_train,\n",
+    "    epochs=3,\n",
+    "    validation_data=ds_test,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_c = 0.0\n",
+    "model.trainable = False\n",
+    "\n",
+    "h2 = BCNewErrorCompatibilityModel([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),\n",
+    "  tf.keras.layers.Dense(128,activation='relu'),\n",
+    "  tf.keras.layers.Dense(10, activation='softmax')\n",
+    "], h1=model, lambda_c=lambda_c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0, 4)"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(model.trainable_weights), len(h2.trainable_weights)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.3190 - accuracy: 0.9091 - val_loss: 0.1956 - val_accuracy: 0.9437\n",
+      "Epoch 2/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.1332 - accuracy: 0.9559 - val_loss: 0.1339 - val_accuracy: 0.9603\n",
+      "Epoch 3/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0923 - accuracy: 0.9677 - val_loss: 0.1148 - val_accuracy: 0.9653\n",
+      "Epoch 4/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0700 - accuracy: 0.9749 - val_loss: 0.0969 - val_accuracy: 0.9708\n",
+      "Epoch 5/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0557 - accuracy: 0.9806 - val_loss: 0.0846 - val_accuracy: 0.9742\n",
+      "Epoch 6/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0454 - accuracy: 0.9843 - val_loss: 0.0865 - val_accuracy: 0.9742\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tensorflow.python.keras.callbacks.History at 0x7f2b8c579128>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h2.compile(\n",
+    "    loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
+    "    optimizer=tf.keras.optimizers.Adam(0.001),\n",
+    "    metrics=['accuracy']\n",
+    ")\n",
+    "\n",
+    "h2.fit(\n",
+    "    ds_train,\n",
+    "    epochs=6,\n",
+    "    validation_data=ds_test,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.trainable = False\n",
+    "h2.trainable = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h1_predicted_labels = []\n",
+    "h2_predicted_labels = []\n",
+    "ground_truth_labels = []\n",
+    "for x_batch_test, y_batch_test in ds_test:\n",
+    "    h1_batch_predictions = tf.argmax(model(x_batch_test), axis=1)\n",
+    "    h2_batch_predictions = tf.argmax(h2(x_batch_test), axis=1)\n",
+    "    h1_predicted_labels += h1_batch_predictions.numpy().tolist()\n",
+    "    h2_predicted_labels += h2_batch_predictions.numpy().tolist()\n",
+    "    ground_truth_labels += y_batch_test.numpy().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lambda_c: 0.0\n",
+      "BTC: 0.9915437764256987\n",
+      "BEC: 0.5808580858085809\n"
+     ]
+    }
+   ],
+   "source": [
+    "btc = scores.trust_compatibility_score(h1_predicted_labels, h2_predicted_labels, ground_truth_labels)\n",
+    "bec = scores.error_compatibility_score(h1_predicted_labels, h2_predicted_labels, ground_truth_labels)\n",
+    "\n",
+    "print(f\"lambda_c: {lambda_c}\")\n",
+    "print(f\"BTC: {btc}\")\n",
+    "print(f\"BEC: {bec}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lambda_c = 0.9\n",
+    "model.trainable = False\n",
+    "\n",
+    "h3 = BCNewErrorCompatibilityModel([\n",
+    "  tf.keras.layers.Flatten(input_shape=(28, 28, 1)),\n",
+    "  tf.keras.layers.Dense(128,activation='relu'),\n",
+    "  tf.keras.layers.Dense(10, activation='softmax')\n",
+    "], h1=model, lambda_c=lambda_c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.3252 - accuracy: 0.9071 - val_loss: 0.1928 - val_accuracy: 0.9426\n",
+      "Epoch 2/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.1359 - accuracy: 0.9540 - val_loss: 0.1412 - val_accuracy: 0.9599\n",
+      "Epoch 3/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0934 - accuracy: 0.9661 - val_loss: 0.1213 - val_accuracy: 0.9643\n",
+      "Epoch 4/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0704 - accuracy: 0.9735 - val_loss: 0.1014 - val_accuracy: 0.9699\n",
+      "Epoch 5/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0563 - accuracy: 0.9780 - val_loss: 0.0969 - val_accuracy: 0.9716\n",
+      "Epoch 6/6\n",
+      "469/469 [==============================] - 1s 2ms/step - loss: 0.0462 - accuracy: 0.9824 - val_loss: 0.0893 - val_accuracy: 0.9713\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<tensorflow.python.keras.callbacks.History at 0x7f2c58193320>"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h3.compile(\n",
+    "    loss=tf.keras.losses.sparse_categorical_crossentropy,\n",
+    "    optimizer=tf.keras.optimizers.Adam(0.001),\n",
+    "    metrics=['accuracy']\n",
+    ")\n",
+    "\n",
+    "h3.fit(\n",
+    "    ds_train,\n",
+    "    epochs=6,\n",
+    "    validation_data=ds_test,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.trainable = False\n",
+    "h3.trainable = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h1_predicted_labels = []\n",
+    "h3_predicted_labels = []\n",
+    "ground_truth_labels = []\n",
+    "for x_batch_test, y_batch_test in ds_test:\n",
+    "    h1_batch_predictions = tf.argmax(model(x_batch_test), axis=1)\n",
+    "    h3_batch_predictions = tf.argmax(h3(x_batch_test), axis=1)\n",
+    "    h1_predicted_labels += h1_batch_predictions.numpy().tolist()\n",
+    "    h3_predicted_labels += h3_batch_predictions.numpy().tolist()\n",
+    "    ground_truth_labels += y_batch_test.numpy().tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lambda_c: 0.9\n",
+      "BTC: 0.9914406517479633\n",
+      "BEC: 0.6732673267326733\n"
+     ]
+    }
+   ],
+   "source": [
+    "btc = scores.trust_compatibility_score(h1_predicted_labels, h3_predicted_labels, ground_truth_labels)\n",
+    "bec = scores.error_compatibility_score(h1_predicted_labels, h3_predicted_labels, ground_truth_labels)\n",
+    "\n",
+    "print(f\"lambda_c: {lambda_c}\")\n",
+    "print(f\"BTC: {btc}\")\n",
+    "print(f\"BEC: {bec}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,10 @@ Jinja2==2.11.2
 numpy==1.19.0
 scikit-learn==0.23.1
 rai_core_flask==0.0.2
+tensorboard==2.3.0
+tensorboard-plugin-wit==1.7.0
+tensorflow==2.3.1
+tensorflow-datasets==4.1.0
+tensorflow-estimator==2.3.0
+tensorflow-metadata==0.25.0
 Pillow==7.2.0


### PR DESCRIPTION
The implementation in Tensorflow is different from the Pytorch implementation as follows:

1. In order to allow the models to be efficiently trained (without eager execution) using the `.fit()` method, we implemented a custom training loop on the model via the `.train_step()` method.

2. If the user has an existing model `h1` and would like to train a new model `h2`, the new model must be instantiated as follows:

```
lambda_c = 0.5
h2 = BCNewErrorCompatibilityModel([ ... keras layers ...], h1=h1, lambda_c=lambda_c)
```

3. And then one may train it using:

```
h2.compile(
    loss=tf.keras.losses.sparse_categorical_crossentropy,
    optimizer=tf.keras.optimizers.Adam(0.001),
    metrics=['accuracy']
)

h2.fit(
    ds_train,
    epochs=6,
    validation_data=ds_test,
)
```

The model `h2` is trained using the Backward Compatibility loss function using the loss function specified by the user in the `.compile()` method above.