### PR TITLE
Integrate MLflow; allow multiple sweeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,8 @@ examples/sweeps-adult/*state
 examples/sweeps-cifar10/*.json
 examples/sweeps-cifar10/*state
 
+mlruns/
+
 tests/sweeps/*.json
 tests/sweeps/*state
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ to see how the `backwardcompatibilityml` module is used.
 
 To demo the widget, open the notebook `compatibility-analysis.ipynb`.
 
+# MLflow
+Compatibility sweeps are automatically logged with [MLflow](https://mlflow.org/). MLflow runs are logged in a folder named `mlruns` in the same directory as the notebook.
+To view the MLflow dashboard, start the MLflow server by running `mlflow server --port 5200 --backend-store-uri ./mlruns`. Then, open the MLflow UI
+in your browser by navigating to `localhost:5200`.
+
 # Tests
 
 To run tests, make sure that you are in the project root folder and do:

--- a/backwardcompatibilityml/helpers/training.py
+++ b/backwardcompatibilityml/helpers/training.py
@@ -721,7 +721,7 @@ def compatibility_sweep(sweeps_folder_path, number_of_epochs, h1, h2,
                         strict_imitation_loss_kwargs=None,
                         get_instance_metadata=None,
                         device="cpu",
-                        use_ml_flow=True,
+                        use_ml_flow=False,
                         ml_flow_run_name="compatibility_sweep"):
     """
     This function trains a new model using the backward compatibility loss function

--- a/backwardcompatibilityml/helpers/training.py
+++ b/backwardcompatibilityml/helpers/training.py
@@ -3,8 +3,9 @@
 
 import copy
 import json
-import torch
+import mlflow
 import numpy as np
+import torch
 import backwardcompatibilityml.scores as scores
 from backwardcompatibilityml.metrics import model_accuracy
 
@@ -719,7 +720,9 @@ def compatibility_sweep(sweeps_folder_path, number_of_epochs, h1, h2,
                         new_error_loss_kwargs=None,
                         strict_imitation_loss_kwargs=None,
                         get_instance_metadata=None,
-                        device="cpu"):
+                        device="cpu",
+                        use_ml_flow=True,
+                        ml_flow_run_name="compatibility_sweep"):
     """
     This function trains a new model using the backward compatibility loss function
     BCNLLLoss with respect to an existing model. It does this for each value of
@@ -766,174 +769,185 @@ def compatibility_sweep(sweeps_folder_path, number_of_epochs, h1, h2,
             value is "cpu". But in case your models reside on the GPU, make sure
             to set this to "cuda". This makes sure that the input and target
             tensors are transferred to the GPU during training.
+        use_ml_flow: A boolean flag controlling whether or not to log the sweep
+            with MLFlow. If true, an MLFlow run will be created with the name
+            specified by ml_flow_run_name.
+        ml_flow_run_name: A string that configures the name of the MLFlow run.
     """
-    import mlflow
-    with mlflow.start_run(run_name='sweep_test_run'):
+    if use_ml_flow:
+        mlflow.start_run(run_name=ml_flow_run_name)
         mlflow.log_param('lambda_c_stepsize', lambda_c_stepsize)
         mlflow.log_param('batch_size_train', batch_size_train)
         mlflow.log_param('batch_size_test', batch_size_test)
 
-        h1.eval()
-        number_of_trainings = 4 * len(np.arange(0.0, 1.0 + (lambda_c_stepsize / 2), lambda_c_stepsize))
-        if percent_complete_queue is not None:
-            percent_complete_queue.put(0.0)
+    h1.eval()
+    number_of_trainings = 4 * len(np.arange(0.0, 1.0 + (lambda_c_stepsize / 2), lambda_c_stepsize))
+    if percent_complete_queue is not None:
+        percent_complete_queue.put(0.0)
 
-        if new_error_loss_kwargs is None:
-            new_error_loss_kwargs = dict()
+    if new_error_loss_kwargs is None:
+        new_error_loss_kwargs = dict()
 
-        if strict_imitation_loss_kwargs is None:
-            strict_imitation_loss_kwargs = dict()
+    if strict_imitation_loss_kwargs is None:
+        strict_imitation_loss_kwargs = dict()
 
-        sweep_summary_data = []
-        datapoint_index = 0
-        run_step = 0
-        for lambda_c in np.arange(0.0, 1.0 + (lambda_c_stepsize / 2), lambda_c_stepsize):
-            run_step += 1
-            h2_new_error = copy.deepcopy(h2)
-            train_new_error(
-                h1, h2_new_error, number_of_epochs,
-                training_set, test_set, batch_size_train, batch_size_test,
-                OptimizerClass, optimizer_kwargs, NewErrorLossClass, lambda_c,
-                new_error_loss_kwargs=new_error_loss_kwargs,
+    sweep_summary_data = []
+    datapoint_index = 0
+    run_step = 0
+    for lambda_c in np.arange(0.0, 1.0 + (lambda_c_stepsize / 2), lambda_c_stepsize):
+        run_step += 1
+        h2_new_error = copy.deepcopy(h2)
+        train_new_error(
+            h1, h2_new_error, number_of_epochs,
+            training_set, test_set, batch_size_train, batch_size_test,
+            OptimizerClass, optimizer_kwargs, NewErrorLossClass, lambda_c,
+            new_error_loss_kwargs=new_error_loss_kwargs,
+            device=device)
+        h2_new_error.eval()
+        torch.save(h2_new_error.state_dict(), f"{sweeps_folder_path}/{lambda_c}-model-new-error.state")
+
+        training_set_performance_and_compatibility =\
+            evaluate_model_performance_and_compatibility_on_dataset(
+                h1, h2_new_error, training_set, performance_metric,
+                get_instance_metadata=get_instance_metadata,
                 device=device)
-            h2_new_error.eval()
-            torch.save(h2_new_error.state_dict(), f"{sweeps_folder_path}/{lambda_c}-model-new-error.state")
-
-            training_set_performance_and_compatibility =\
-                evaluate_model_performance_and_compatibility_on_dataset(
-                    h1, h2_new_error, training_set, performance_metric,
-                    get_instance_metadata=get_instance_metadata,
-                    device=device)
-            training_set_performance_and_compatibility["lambda_c"] = lambda_c
-            training_set_performance_and_compatibility["training"] = True
-            training_set_performance_and_compatibility["testing"] = False
-            training_set_performance_and_compatibility["datapoint_index"] = datapoint_index
-            sweep_summary_data.append({
-                "datapoint_index": datapoint_index,
-                "lambda_c": lambda_c,
-                "training": True,
-                "testing": False,
-                "new-error": True,
-                "strict-imitation": False,
-                "performance": training_set_performance_and_compatibility["h2_performance"],
-                "btc": training_set_performance_and_compatibility["btc"],
-                "bec": training_set_performance_and_compatibility["bec"]
-            })
+        training_set_performance_and_compatibility["lambda_c"] = lambda_c
+        training_set_performance_and_compatibility["training"] = True
+        training_set_performance_and_compatibility["testing"] = False
+        training_set_performance_and_compatibility["datapoint_index"] = datapoint_index
+        sweep_summary_data.append({
+            "datapoint_index": datapoint_index,
+            "lambda_c": lambda_c,
+            "training": True,
+            "testing": False,
+            "new-error": True,
+            "strict-imitation": False,
+            "performance": training_set_performance_and_compatibility["h2_performance"],
+            "btc": training_set_performance_and_compatibility["btc"],
+            "bec": training_set_performance_and_compatibility["bec"]
+        })
+        if use_ml_flow:
+            mlflow.log_metric(f"lambda_c", lambda_c, step=run_step)
             mlflow.log_metric(f"new_error_training_performance", training_set_performance_and_compatibility["h2_performance"], step=run_step)
             mlflow.log_metric(f"new_error_training_btc", training_set_performance_and_compatibility["btc"], step=run_step)
             mlflow.log_metric(f"new_error_training_bec", training_set_performance_and_compatibility["bec"], step=run_step)
-            training_evaluation_data = json.dumps(training_set_performance_and_compatibility)
-            training_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
-            training_evaluation_data_file.write(training_evaluation_data)
-            training_evaluation_data_file.close()
-            datapoint_index += 1
+        training_evaluation_data = json.dumps(training_set_performance_and_compatibility)
+        training_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
+        training_evaluation_data_file.write(training_evaluation_data)
+        training_evaluation_data_file.close()
+        datapoint_index += 1
 
-            testing_set_performance_and_compatibility =\
-                evaluate_model_performance_and_compatibility_on_dataset(
-                    h1, h2_new_error, test_set, performance_metric,
-                    get_instance_metadata=get_instance_metadata,
-                    device=device)
-            testing_set_performance_and_compatibility["lambda_c"] = lambda_c
-            testing_set_performance_and_compatibility["training"] = False
-            testing_set_performance_and_compatibility["testing"] = True
-            testing_set_performance_and_compatibility["datapoint_index"] = datapoint_index
-            sweep_summary_data.append({
-                "datapoint_index": datapoint_index,
-                "lambda_c": lambda_c,
-                "training": False,
-                "testing": True,
-                "new-error": True,
-                "strict-imitation": False,
-                "performance": testing_set_performance_and_compatibility["h2_performance"],
-                "btc": testing_set_performance_and_compatibility["btc"],
-                "bec": testing_set_performance_and_compatibility["bec"]
-            })
+        testing_set_performance_and_compatibility =\
+            evaluate_model_performance_and_compatibility_on_dataset(
+                h1, h2_new_error, test_set, performance_metric,
+                get_instance_metadata=get_instance_metadata,
+                device=device)
+        testing_set_performance_and_compatibility["lambda_c"] = lambda_c
+        testing_set_performance_and_compatibility["training"] = False
+        testing_set_performance_and_compatibility["testing"] = True
+        testing_set_performance_and_compatibility["datapoint_index"] = datapoint_index
+        sweep_summary_data.append({
+            "datapoint_index": datapoint_index,
+            "lambda_c": lambda_c,
+            "training": False,
+            "testing": True,
+            "new-error": True,
+            "strict-imitation": False,
+            "performance": testing_set_performance_and_compatibility["h2_performance"],
+            "btc": testing_set_performance_and_compatibility["btc"],
+            "bec": testing_set_performance_and_compatibility["bec"]
+        })
+        if use_ml_flow:
             mlflow.log_metric(f"new_error_testing_performance", testing_set_performance_and_compatibility["h2_performance"], step=run_step)
             mlflow.log_metric(f"new_error_testing_btc", testing_set_performance_and_compatibility["btc"], step=run_step)
             mlflow.log_metric(f"new_error_testing_bec", testing_set_performance_and_compatibility["bec"], step=run_step)
-            testing_evaluation_data = json.dumps(testing_set_performance_and_compatibility)
-            testing_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
-            testing_evaluation_data_file.write(testing_evaluation_data)
-            testing_evaluation_data_file.close()
-            datapoint_index += 1
+        testing_evaluation_data = json.dumps(testing_set_performance_and_compatibility)
+        testing_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
+        testing_evaluation_data_file.write(testing_evaluation_data)
+        testing_evaluation_data_file.close()
+        datapoint_index += 1
 
-            h2_strict_imitation = copy.deepcopy(h2)
-            train_strict_imitation(
-                h1, h2_strict_imitation, number_of_epochs,
-                training_set, test_set, batch_size_train, batch_size_test,
-                OptimizerClass, optimizer_kwargs, StrictImitationLossClass, lambda_c,
-                strict_imitation_loss_kwargs=strict_imitation_loss_kwargs,
+        h2_strict_imitation = copy.deepcopy(h2)
+        train_strict_imitation(
+            h1, h2_strict_imitation, number_of_epochs,
+            training_set, test_set, batch_size_train, batch_size_test,
+            OptimizerClass, optimizer_kwargs, StrictImitationLossClass, lambda_c,
+            strict_imitation_loss_kwargs=strict_imitation_loss_kwargs,
+            device=device)
+        h2_strict_imitation.eval()
+        torch.save(h2_strict_imitation.state_dict(), f"{sweeps_folder_path}/{lambda_c}-model-strict-imitation.state")
+
+        training_set_performance_and_compatibility =\
+            evaluate_model_performance_and_compatibility_on_dataset(
+                h1, h2_strict_imitation, training_set, performance_metric,
+                get_instance_metadata=get_instance_metadata,
                 device=device)
-            h2_strict_imitation.eval()
-            torch.save(h2_strict_imitation.state_dict(), f"{sweeps_folder_path}/{lambda_c}-model-strict-imitation.state")
-
-            training_set_performance_and_compatibility =\
-                evaluate_model_performance_and_compatibility_on_dataset(
-                    h1, h2_strict_imitation, training_set, performance_metric,
-                    get_instance_metadata=get_instance_metadata,
-                    device=device)
-            training_set_performance_and_compatibility["lambda_c"] = lambda_c
-            training_set_performance_and_compatibility["training"] = True
-            training_set_performance_and_compatibility["testing"] = False
-            training_set_performance_and_compatibility["datapoint_index"] = datapoint_index
-            sweep_summary_data.append({
-                "datapoint_index": datapoint_index,
-                "lambda_c": lambda_c,
-                "training": True,
-                "testing": False,
-                "new-error": False,
-                "strict-imitation": True,
-                "performance": training_set_performance_and_compatibility["h2_performance"],
-                "btc": training_set_performance_and_compatibility["btc"],
-                "bec": training_set_performance_and_compatibility["bec"]
-            })
+        training_set_performance_and_compatibility["lambda_c"] = lambda_c
+        training_set_performance_and_compatibility["training"] = True
+        training_set_performance_and_compatibility["testing"] = False
+        training_set_performance_and_compatibility["datapoint_index"] = datapoint_index
+        sweep_summary_data.append({
+            "datapoint_index": datapoint_index,
+            "lambda_c": lambda_c,
+            "training": True,
+            "testing": False,
+            "new-error": False,
+            "strict-imitation": True,
+            "performance": training_set_performance_and_compatibility["h2_performance"],
+            "btc": training_set_performance_and_compatibility["btc"],
+            "bec": training_set_performance_and_compatibility["bec"]
+        })
+        if use_ml_flow:
             mlflow.log_metric(f"strict_imitation_training_performance", training_set_performance_and_compatibility["h2_performance"], step=run_step)
             mlflow.log_metric(f"strict_imitation_training_btc", training_set_performance_and_compatibility["btc"], step=run_step)
             mlflow.log_metric(f"strict_imitation_training_bec", training_set_performance_and_compatibility["bec"], step=run_step)
-            training_evaluation_data = json.dumps(training_set_performance_and_compatibility)
-            training_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
-            training_evaluation_data_file.write(training_evaluation_data)
-            training_evaluation_data_file.close()
-            datapoint_index += 1
+        training_evaluation_data = json.dumps(training_set_performance_and_compatibility)
+        training_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
+        training_evaluation_data_file.write(training_evaluation_data)
+        training_evaluation_data_file.close()
+        datapoint_index += 1
 
-            testing_set_performance_and_compatibility =\
-                evaluate_model_performance_and_compatibility_on_dataset(
-                    h1, h2_new_error, test_set, performance_metric,
-                    get_instance_metadata=get_instance_metadata,
-                    device=device)
-            testing_set_performance_and_compatibility["lambda_c"] = lambda_c
-            testing_set_performance_and_compatibility["training"] = False
-            testing_set_performance_and_compatibility["testing"] = True
-            testing_set_performance_and_compatibility["datapoint_index"] = datapoint_index
-            sweep_summary_data.append({
-                "datapoint_index": datapoint_index,
-                "lambda_c": lambda_c,
-                "training": False,
-                "testing": True,
-                "new-error": False,
-                "strict-imitation": True,
-                "performance": testing_set_performance_and_compatibility["h2_performance"],
-                "btc": testing_set_performance_and_compatibility["btc"],
-                "bec": testing_set_performance_and_compatibility["bec"]
-            })
+        testing_set_performance_and_compatibility =\
+            evaluate_model_performance_and_compatibility_on_dataset(
+                h1, h2_new_error, test_set, performance_metric,
+                get_instance_metadata=get_instance_metadata,
+                device=device)
+        testing_set_performance_and_compatibility["lambda_c"] = lambda_c
+        testing_set_performance_and_compatibility["training"] = False
+        testing_set_performance_and_compatibility["testing"] = True
+        testing_set_performance_and_compatibility["datapoint_index"] = datapoint_index
+        sweep_summary_data.append({
+            "datapoint_index": datapoint_index,
+            "lambda_c": lambda_c,
+            "training": False,
+            "testing": True,
+            "new-error": False,
+            "strict-imitation": True,
+            "performance": testing_set_performance_and_compatibility["h2_performance"],
+            "btc": testing_set_performance_and_compatibility["btc"],
+            "bec": testing_set_performance_and_compatibility["bec"]
+        })
+        if use_ml_flow:
             mlflow.log_metric(f"strict_imitation_testing_performance", testing_set_performance_and_compatibility["h2_performance"], step=run_step)
             mlflow.log_metric(f"strict_imitation_testing_btc", testing_set_performance_and_compatibility["btc"], step=run_step)
             mlflow.log_metric(f"strict_imitation_testing_bec", testing_set_performance_and_compatibility["bec"], step=run_step)
-            testing_evaluation_data = json.dumps(testing_set_performance_and_compatibility)
-            testing_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
-            testing_evaluation_data_file.write(testing_evaluation_data)
-            testing_evaluation_data_file.close()
-            datapoint_index += 1
+        testing_evaluation_data = json.dumps(testing_set_performance_and_compatibility)
+        testing_evaluation_data_file = open(f"{sweeps_folder_path}/{datapoint_index}-evaluation-data.json", "w")
+        testing_evaluation_data_file.write(testing_evaluation_data)
+        testing_evaluation_data_file.close()
+        datapoint_index += 1
 
-            if percent_complete_queue is not None:
-                percent_complete_queue.put((datapoint_index) / number_of_trainings)
+        if percent_complete_queue is not None:
+            percent_complete_queue.put((datapoint_index) / number_of_trainings)
 
-        sweep_summary = {
-            "data": sweep_summary_data,
-            "h1_performance": model_accuracy(h1, test_set, device=device)
-        }
+    sweep_summary = {
+        "data": sweep_summary_data,
+        "h1_performance": model_accuracy(h1, test_set, device=device)
+    }
 
-        sweep_summary_data = json.dumps(sweep_summary)
-        sweep_summary_data_file = open(f"{sweeps_folder_path}/sweep_summary.json", "w")
-        sweep_summary_data_file.write(sweep_summary_data)
-        sweep_summary_data_file.close()
+    sweep_summary_data = json.dumps(sweep_summary)
+    sweep_summary_data_file = open(f"{sweeps_folder_path}/sweep_summary.json", "w")
+    sweep_summary_data_file.write(sweep_summary_data)
+    sweep_summary_data_file.close()
+    if use_ml_flow:
+        mlflow.end_run()

--- a/backwardcompatibilityml/sweep_management.py
+++ b/backwardcompatibilityml/sweep_management.py
@@ -66,6 +66,10 @@ class SweepManager(object):
             value is "cpu". But in case your models reside on the GPU, make sure
             to set this to "cuda". This makes sure that the input and target
             tensors are transferred to the GPU during training.
+        use_ml_flow: A boolean flag controlling whether or not to log the sweep
+            with MLFlow. If true, an MLFlow run will be created with the name
+            specified by ml_flow_run_name.
+        ml_flow_run_name: A string that configures the name of the MLFlow run.
     """
 
     def __init__(self, folder_name, number_of_epochs, h1, h2, training_set, test_set,
@@ -77,7 +81,9 @@ class SweepManager(object):
                  performance_metric=model_accuracy,
                  get_instance_image_by_id=None,
                  get_instance_metadata=None,
-                 device="cpu"):
+                 device="cpu",
+                 use_ml_flow=True,
+                 ml_flow_run_name="compatibility_sweep"):
         self.folder_name = folder_name
         self.number_of_epochs = number_of_epochs
         self.h1 = h1
@@ -97,6 +103,8 @@ class SweepManager(object):
         self.get_instance_image_by_id = get_instance_image_by_id
         self.get_instance_metadata = get_instance_metadata
         self.device = device
+        self.use_ml_flow = use_ml_flow
+        self.ml_flow_run_name = ml_flow_run_name
         self.last_sweep_status = 0.0
         self.percent_complete_queue = Queue()
         self.sweep_thread = None
@@ -120,7 +128,9 @@ class SweepManager(object):
                 "new_error_loss_kwargs": self.new_error_loss_kwargs,
                 "strict_imitation_loss_kwargs": self.strict_imitation_loss_kwargs,
                 "get_instance_metadata": self.get_instance_metadata,
-                "device": self.device
+                "device": self.device,
+                "use_ml_flow": self.use_ml_flow,
+                "ml_flow_run_name": self.ml_flow_run_name
             })
         self.sweep_thread.start()
 
@@ -140,101 +150,6 @@ class SweepManager(object):
             strict_imitation_loss_kwargs=self.strict_imitation_loss_kwargs,
             get_instance_metadata=self.get_instance_metadata,
             device=self.device)
-
-    def get_sweep_status(self):
-        if not self.percent_complete_queue.empty():
-            while not self.percent_complete_queue.empty():
-                self.last_sweep_status = self.percent_complete_queue.get()
-
-        return self.last_sweep_status
-
-    def get_sweep_summary(self):
-        sweep_summary = {
-            "h1_performance": None,
-            "performance_metric": self.performance_metric.__name__,
-            "data": []
-        }
-
-        if os.path.exists(f"{self.folder_name}/sweep_summary.json"):
-            with open(f"{self.folder_name}/sweep_summary.json", "r") as sweep_summary_file:
-                loaded_sweep_summary = json.loads(sweep_summary_file.read())
-                sweep_summary.update(loaded_sweep_summary)
-
-        return sweep_summary
-
-    def get_evaluation(self, evaluation_id):
-        with open(f"{self.folder_name}/{evaluation_id}-evaluation-data.json", "r") as evaluation_data_file:
-            evaluation_data = json.loads(evaluation_data_file.read())
-
-        return evaluation_data
-
-    def get_instance_image(self, instance_id):
-        get_instance_image_by_id = self.get_instance_image_by_id
-        if get_instance_image_by_id is not None:
-            return get_instance_image_by_id(instance_id)
-
-        # Generate a blank white PNG image as the default
-        data = np.uint8(np.zeros((30, 30)) + 255)
-        image = Image.fromarray(data)
-        img_bytes = io.BytesIO()
-        image.save(img_bytes, format="PNG")
-        img_bytes.seek(0)
-
-        return send_file(img_bytes, mimetype="image/png")
-
-class MLFlowSweepManager(object):
-    def __init__(self, folder_name, number_of_epochs, h1, h2, training_set, test_set,
-                 batch_size_train, batch_size_test,
-                 OptimizerClass, optimizer_kwargs,
-                 NewErrorLossClass, StrictImitationLossClass, lambda_c_stepsize=0.25,
-                 new_error_loss_kwargs=None,
-                 strict_imitation_loss_kwargs=None,
-                 performance_metric=model_accuracy,
-                 get_instance_image_by_id=None,
-                 get_instance_metadata=None,
-                 device="cpu"):
-        self.folder_name = folder_name
-        self.number_of_epochs = number_of_epochs
-        self.h1 = h1
-        self.h2 = h2
-        self.training_set = training_set
-        self.test_set = test_set
-        self.batch_size_train = batch_size_train
-        self.batch_size_test = batch_size_test
-        self.OptimizerClass = OptimizerClass
-        self.optimizer_kwargs = optimizer_kwargs
-        self.NewErrorLossClass = NewErrorLossClass
-        self.StrictImitationLossClass = StrictImitationLossClass
-        self.performance_metric = performance_metric
-        self.lambda_c_stepsize = lambda_c_stepsize
-        self.new_error_loss_kwargs = new_error_loss_kwargs
-        self.strict_imitation_loss_kwargs = strict_imitation_loss_kwargs
-        self.get_instance_image_by_id = get_instance_image_by_id
-        self.get_instance_metadata = get_instance_metadata
-        self.device = device
-        self.last_sweep_status = 0.0
-        self.percent_complete_queue = Queue()
-
-    def start_sweep(self):
-        if self.is_running():
-            return
-        training.compatibility_sweep(
-            self.folder_name, self.number_of_epochs, self.h1, self.h2, self.training_set, self.test_set,
-            self.batch_size_train, self.batch_size_test,
-            self.OptimizerClass, self.optimizer_kwargs,
-            self.NewErrorLossClass, self.StrictImitationLossClass,
-            lambda_c_stepsize=self.lambda_c_stepsize, percent_complete_queue=self.percent_complete_queue,
-            new_error_loss_kwargs=self.new_error_loss_kwargs,
-            strict_imitation_loss_kwargs=self.strict_imitation_loss_kwargs,
-            get_instance_metadata=self.get_instance_metadata,
-            device=self.device)
-
-    def is_running(self):
-        run = mlflow.active_run()
-        if run:
-            return not mlflow.entities.run_status.RunStatus.is_terminated(run.info.status)
-        else:
-            return False
 
     def get_sweep_status(self):
         if not self.percent_complete_queue.empty():

--- a/backwardcompatibilityml/sweep_management.py
+++ b/backwardcompatibilityml/sweep_management.py
@@ -82,7 +82,7 @@ class SweepManager(object):
                  get_instance_image_by_id=None,
                  get_instance_metadata=None,
                  device="cpu",
-                 use_ml_flow=True,
+                 use_ml_flow=False,
                  ml_flow_run_name="compatibility_sweep"):
         self.folder_name = folder_name
         self.number_of_epochs = number_of_epochs

--- a/backwardcompatibilityml/widget/compatibility_analysis.py
+++ b/backwardcompatibilityml/widget/compatibility_analysis.py
@@ -224,7 +224,7 @@ class CompatibilityAnalysis(object):
                  get_instance_image_by_id=None,
                  get_instance_metadata=None,
                  device="cpu",
-                 use_ml_flow=True,
+                 use_ml_flow=False,
                  ml_flow_run_name="compatibility_sweep"):
         if OptimizerClass is None:
             OptimizerClass = optim.SGD

--- a/backwardcompatibilityml/widget/compatibility_analysis.py
+++ b/backwardcompatibilityml/widget/compatibility_analysis.py
@@ -11,7 +11,7 @@ from IPython.display import (
 import torch.optim as optim
 from flask import Response
 from backwardcompatibilityml import loss
-from backwardcompatibilityml.sweep_management import (SweepManager, MLFlowSweepManager)
+from backwardcompatibilityml.sweep_management import SweepManager
 from backwardcompatibilityml.metrics import model_accuracy
 from rai_core_flask.flask_helper import FlaskHelper
 from rai_core_flask.environments import (
@@ -208,6 +208,10 @@ class CompatibilityAnalysis(object):
             value is "cpu". But in case your models reside on the GPU, make sure 
             to set this to "cuda". This makes sure that the input and target 
             tensors are transferred to the GPU during training.
+        use_ml_flow: A boolean flag controlling whether or not to log the sweep
+            with MLFlow. If true, an MLFlow run will be created with the name
+            specified by ml_flow_run_name.
+        ml_flow_run_name: A string that configures the name of the MLFlow run.
     """
 
     def __init__(self, folder_name, number_of_epochs, h1, h2, training_set, test_set,
@@ -219,7 +223,9 @@ class CompatibilityAnalysis(object):
                  strict_imitation_loss_kwargs=None,
                  get_instance_image_by_id=None,
                  get_instance_metadata=None,
-                 device="cpu"):
+                 device="cpu",
+                 use_ml_flow=True,
+                 ml_flow_run_name="compatibility_sweep"):
         if OptimizerClass is None:
             OptimizerClass = optim.SGD
 
@@ -253,7 +259,9 @@ class CompatibilityAnalysis(object):
             performance_metric=performance_metric,
             get_instance_image_by_id=get_instance_image_by_id,
             get_instance_metadata=get_instance_metadata,
-            device=device)
+            device=device,
+            use_ml_flow=use_ml_flow,
+            ml_flow_run_name=ml_flow_run_name)
 
         self.flask_service = FlaskHelper(ip="0.0.0.0", port=port)
         app_has_routes = False

--- a/development/app.py
+++ b/development/app.py
@@ -209,6 +209,6 @@ def mnist_sweep():
                           device="cuda")
 
 
-mnist_sweep()
+breast_cancer_sweep()
 app = FlaskHelper.app
 app.logger.info('initialization complete')

--- a/development/app.py
+++ b/development/app.py
@@ -19,6 +19,8 @@ from flask import send_file
 from PIL import Image
 from rai_core_flask.flask_helper import FlaskHelper
 
+use_ml_flow = True
+ml_flow_run_name = "dev_app_sweep"
 
 def breast_cancer_sweep():
     folder_name = "tests/sweeps"
@@ -95,7 +97,9 @@ def breast_cancer_sweep():
         OptimizerClass=optim.SGD,
         optimizer_kwargs={"lr": learning_rate, "momentum": momentum},
         NewErrorLossClass=bcloss.BCCrossEntropyLoss,
-        StrictImitationLossClass=bcloss.StrictImitationCrossEntropyLoss)
+        StrictImitationLossClass=bcloss.StrictImitationCrossEntropyLoss,
+        use_ml_flow=use_ml_flow,
+        ml_flow_run_name=ml_flow_run_name)
 
 
 def mnist_sweep():
@@ -206,7 +210,9 @@ def mnist_sweep():
                           lambda_c_stepsize=0.25,
                           get_instance_image_by_id=get_instance_image,
                           get_instance_metadata=get_instance_label,
-                          device="cuda")
+                          device="cuda",
+                          use_ml_flow=use_ml_flow,
+                          ml_flow_run_name=ml_flow_run_name)
 
 
 breast_cancer_sweep()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy==1.19.0
 scikit-learn==0.23.1
 rai_core_flask==0.0.2
 Pillow==7.2.0
+mlflow==1.12.1

--- a/widget/SweepManager.tsx
+++ b/widget/SweepManager.tsx
@@ -6,10 +6,6 @@ import ReactDOM from "react-dom";
 import * as d3 from "d3";
 
 
-type SweepManagerState = {
-  sweepStatus: any
-}
-
 type SweepManagerProps = {
   sweepStatus: any,
   getSweepStatus: () => void,
@@ -17,25 +13,15 @@ type SweepManagerProps = {
   getTrainingAndTestingData: () => void
 }
 
-class SweepManager extends Component<SweepManagerProps, SweepManagerState> {
+class SweepManager extends Component<SweepManagerProps> {
   constructor(props) {
     super(props);
-
-    this.state = {
-      sweepStatus: this.props.sweepStatus
-    };
 
     this.pollSweepStatus = this.pollSweepStatus.bind(this);
     this.startSweep = this.startSweep.bind(this);
   }
 
-  timeoutVar: any = null
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      sweepStatus: nextProps.sweepStatus
-    });
-  }
+  timeoutVar: NodeJS.Timeout = null
 
   componentWillUnmount() {
     if (this.timeoutVar != null) {
@@ -54,13 +40,13 @@ class SweepManager extends Component<SweepManagerProps, SweepManagerState> {
 
   startSweep(evt) {
     this.props.startSweep();
-    this.pollSweepStatus();
+    this.timeoutVar = setTimeout(this.pollSweepStatus, 500);
   }
 
   render() {
 
-    if (this.state.sweepStatus == null || !this.state.sweepStatus.running) {
-      if (this.timeoutVar != null && this.state.sweepStatus.percent_complete == 1.0) {
+    if (this.props.sweepStatus == null || !this.props.sweepStatus.running) {
+      if (this.timeoutVar != null && this.props.sweepStatus.percent_complete == 1.0) {
         clearTimeout(this.timeoutVar);
         this.timeoutVar = null;
         this.props.getTrainingAndTestingData();
@@ -77,7 +63,7 @@ class SweepManager extends Component<SweepManagerProps, SweepManagerState> {
       <div className="table">
         Sweep in progress
         <div>
-         {Math.floor(this.state.sweepStatus.percent_complete * 100)} % complete
+         {Math.floor(this.props.sweepStatus.percent_complete * 100)} % complete
         </div>
       </div>
     );

--- a/widget/actions.ts
+++ b/widget/actions.ts
@@ -131,7 +131,6 @@ function getSweepStatus() {
 
 function startSweep() {
     return function(dispatch) {
-        dispatch(getSweepStatus());
         makePostCall("api/v1/start_sweep", {});
     }
 }


### PR DESCRIPTION
This PR integrates MLflow support into the backend. MLflow can be controlled from the CompatibilityAnalysis API with parameters use_ml_flow and ml_flow_run_name. If use_ml_flow=False, we will not log the sweep with MLflow.

This PR also contains bug fixes for https://github.com/microsoft/BackwardCompatibilityML/issues/87. The widget can now be instantiated multiple times, and a sweep can be run multiple times without crashing the widget.