### PR TITLE
Error instances pagination fix

### DIFF
--- a/widgets/common/ErrorInstancesTable.tsx
+++ b/widgets/common/ErrorInstancesTable.tsx
@@ -46,11 +46,9 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
         return (nextProps.filterInstances.indexOf(errorInstance.instance_id) != -1)
       });
     }
-    const numPages = Math.ceil(errorInstances.length / nextProps.pageSize);
-
     this.setState({
       selecedDataPoint: nextProps.selecedDataPoint,
-      page: Math.min(numPages-1, this.state.page)
+      page: 0
     });
   }
 

--- a/widgets/common/ErrorInstancesTable.tsx
+++ b/widgets/common/ErrorInstancesTable.tsx
@@ -39,8 +39,6 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
     }
   }
 
-  calculateNumPages
-
   componentWillReceiveProps(nextProps) {
     let errorInstances = nextProps.selectedDataPoint.error_instances;
     if (nextProps.filterInstances != null) {

--- a/widgets/common/ErrorInstancesTable.tsx
+++ b/widgets/common/ErrorInstancesTable.tsx
@@ -39,9 +39,20 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
     }
   }
 
+  calculateNumPages
+
   componentWillReceiveProps(nextProps) {
+    let errorInstances = nextProps.selectedDataPoint.error_instances;
+    if (nextProps.filterInstances != null) {
+      errorInstances = nextProps.selectedDataPoint.error_instances.filter(errorInstance => {
+        return (nextProps.filterInstances.indexOf(errorInstance.instance_id) != -1)
+      });
+    }
+    const numPages = Math.ceil(errorInstances.length / nextProps.pageSize);
+
     this.setState({
-      selecedDataPoint: nextProps.selecedDataPoint
+      selecedDataPoint: nextProps.selecedDataPoint,
+      page: Math.min(numPages-1, this.state.page)
     });
   }
 
@@ -91,7 +102,7 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
       items.push(errorInstances[i]);
     }
 
-    const numPages = Math.ceil(this.props.selectedDataPoint.error_instances.length / this.props.pageSize);
+    const numPages = Math.ceil(errorInstances.length / this.props.pageSize);
 
     return (
       <Fabric styles={{root: {width: 700}}}>
@@ -107,11 +118,11 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
                 page: Math.max(0, this.state.page - 1)
               })
             }}>&lt;</button>
-          <span aria-label="error page number">{this.state.page+1} of {numPages+1}</span>
+          <span aria-label="error page number">{this.state.page+1} of {numPages}</span>
           <button
             onClick={() => {
               this.setState({
-                page: Math.min(this.state.page + 1, numPages)
+                page: Math.min(this.state.page + 1, numPages-1)
               })
             }}>&gt;</button>
         </div>

--- a/widgets/compatibilityanalysis/reducers.ts
+++ b/widgets/compatibilityanalysis/reducers.ts
@@ -55,7 +55,7 @@ function rootReducer(state = initialState, action) {
           return Object.assign({}, state, {filterInstances: null, loading: true});
 
         case "REQUEST_MODEL_EVALUATION_DATA_SUCCEEDED":
-          return Object.assign({}, state, {filterInstances: null, selectedDataPoint: action.evaluationData, loading: false});
+          return Object.assign({}, state, {filterInstances: null, selectedDataPoint: action.evaluationData, selectedRegion: null, selectedClass: null, loading: false});
 
         case "REQUEST_MODEL_EVALUATION_DATA_FAILED":
           console.log("Error: ", action.error);


### PR DESCRIPTION
Bug fixes for the following issues:
https://github.com/microsoft/BackwardCompatibilityML/issues/95 Error instances table - pagination component shows total number of pages even after filtering
https://github.com/microsoft/BackwardCompatibilityML/issues/96 Venn diagram nor histogram reset when clicking on a new scatter plot data point