### PR TITLE
Fix the error TypeError Cannot read property 'error_instances' of null

### DIFF
--- a/widgets/common/ErrorInstancesTable.tsx
+++ b/widgets/common/ErrorInstancesTable.tsx
@@ -40,12 +40,6 @@ class ErrorInstancesTable extends Component<ErrorInstancesTableProps, ErrorInsta
   }
 
   componentWillReceiveProps(nextProps) {
-    let errorInstances = nextProps.selectedDataPoint.error_instances;
-    if (nextProps.filterInstances != null) {
-      errorInstances = nextProps.selectedDataPoint.error_instances.filter(errorInstance => {
-        return (nextProps.filterInstances.indexOf(errorInstance.instance_id) != -1)
-      });
-    }
     this.setState({
       selecedDataPoint: nextProps.selecedDataPoint,
       page: 0


### PR DESCRIPTION
Fixes the null reference crash for https://github.com/microsoft/BackwardCompatibilityML/issues/108

The broken code was a prototype for a feature I removed earlier. When fixing the pagination in the error instances table, I had a prototype to save the page you were on if you switched what data you were filtering. But we don't actually need that, because it makes more sense to always start from page 1.