### PR TITLE
Add docstrings to Tensorflow models module, and add more Tensorflow documentation in topics section

### DIFF
--- a/backwardcompatibilityml/tensorflow/helpers.py
+++ b/backwardcompatibilityml/tensorflow/helpers.py
@@ -2,6 +2,44 @@ import tensorflow.compat.v2 as tf
 
 
 def bc_fit(h2, training_set=None, testing_set=None, epochs=None, bc_loss=None, optimizer=None):
+    """
+    This function is used to train a model h2, using an instance of a Tensorflow BCLoss function
+    that has been instantiated using an existing model h1 and regularization parameter lambda_c.
+
+    Example usage:
+
+        h2 = tf.keras.models.Sequential([
+          tf.keras.layers.Flatten(input_shape=(28, 28, 1)),
+          tf.keras.layers.Dense(128,activation='relu'),
+          tf.keras.layers.Dense(10, activation='softmax')
+        ])
+
+        lambda_c = 0.9
+        h1.trainable = False
+        bc_loss = BCCrossEntropyLoss(h1, h2, lambda_c)
+
+        optimizer = tf.keras.optimizers.Adam(0.001)
+
+        tf_helpers.bc_fit(
+            h2,
+            training_set=ds_train,
+            testing_set=ds_test,
+            epochs=6,
+            bc_loss=bc_loss,
+            optimizer=optimizer)
+
+    Args:
+        h2: A Tensorflow model that we want to train using backward compatibility.
+        training_set: The training set to use to train our model.
+        testing_set: The testing set to use to validate our model.
+        epochs: The number of training epochs.
+        bc_loss: An instance of a Tensorflow BCLoss function.
+        optimizer: The optimizer to use.
+
+    Returns:
+        Does not return anything. But it updates the weights of the model h2.
+    """
+
     @tf.function
     def compatibility_train_step(x_batch_train, y_batch_train, bc_loss, optimizer, h2):
         # Open a GradientTape to record the operations run

--- a/backwardcompatibilityml/tensorflow/helpers.py
+++ b/backwardcompatibilityml/tensorflow/helpers.py
@@ -30,8 +30,8 @@ def bc_fit(h2, training_set=None, testing_set=None, epochs=None, bc_loss=None, o
 
     Args:
         h2: A Tensorflow model that we want to train using backward compatibility.
-        training_set: The training set to use to train our model.
-        testing_set: The testing set to use to validate our model.
+        training_set: The training set for our model.
+        testing_set: The testing set for validating our model.
         epochs: The number of training epochs.
         bc_loss: An instance of a Tensorflow BCLoss function.
         optimizer: The optimizer to use.

--- a/backwardcompatibilityml/tensorflow/models.py
+++ b/backwardcompatibilityml/tensorflow/models.py
@@ -8,9 +8,9 @@ class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
     """
     BackwardCompatibility base model for Tensorflow
 
-    One may create a new Tensorflow model by subclassing
-    their new model h2 from this model.
-    This allows one to train or update a new model h2, using the
+    You may create a new Tensorflow model by subclassing
+    your new model h2 from this model.
+    This allows you to train or update a new model h2, using the
     backward compatibility loss, with respect to an existing
     model h1, using the Tensorflow fit method, h2.fit(...).
 

--- a/backwardcompatibilityml/tensorflow/models.py
+++ b/backwardcompatibilityml/tensorflow/models.py
@@ -5,6 +5,40 @@ import tensorflow.compat.v2 as tf
 
 
 class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
+    """
+    BackwardCompatibility base model for Tensorflow
+
+    One may create a new Tensorflow model by subclassing
+    their new model h2 from this model.
+    This allows one to train or update a new model h2, using the
+    backward compatibility loss, with respect to an existing
+    model h1, using the Tensorflow fit method, h2.fit(...).
+
+    Assuming that you have a pre-trained model h1 and you
+    would like to create a new model h2 that you train
+    using the backward compatibility loss with respect to h1,
+    the following describes the example usage:
+
+        h1.trainable = False
+
+        h2 = BCNewErrorCompatibilityModel([
+          tf.keras.layers.Flatten(input_shape=(28, 28, 1)),
+          tf.keras.layers.Dense(128,activation='relu'),
+          tf.keras.layers.Dense(10, activation='softmax')
+        ], h1=h1, lambda_c=0.7)
+
+        h2.compile(
+            loss=tf.keras.losses.sparse_categorical_crossentropy,
+            optimizer=tf.keras.optimizers.Adam(0.001),
+            metrics=['accuracy']
+        )
+
+        h2.fit(
+            dataset_train,
+            epochs=6,
+            validation_data=dataset_test,
+        )
+    """
 
     def __init__(self, *args, h1=None, lambda_c=0.0, **kwargs):
         """

--- a/backwardcompatibilityml/tensorflow/models.py
+++ b/backwardcompatibilityml/tensorflow/models.py
@@ -15,7 +15,7 @@ class BCNewErrorCompatibilityModel(tf.keras.models.Sequential):
     model h1, using the Tensorflow fit method, h2.fit(...).
 
     Assuming that you have a pre-trained model h1 and you
-    would like to create a new model h2 that you train
+    would like to create a new model h2 trained
     using the backward compatibility loss with respect to h1,
     the following describes the example usage:
 

--- a/docs/backwardcompatibilityml/topics.rst
+++ b/docs/backwardcompatibilityml/topics.rst
@@ -11,3 +11,4 @@ Help Topics
     topics/integrating_loss_functions
     topics/using_the_compatibility_analysis_widget
     topics/using_and_integrating_the_model_comparison_widget
+    topics/using_the_tensorflow_interface

--- a/docs/backwardcompatibilityml/topics/using_the_tensorflow_interface.rst
+++ b/docs/backwardcompatibilityml/topics/using_the_tensorflow_interface.rst
@@ -1,0 +1,93 @@
+.. _using_the_tensorflow_interface:
+
+The Tensorflow Interface
+=================================================================
+
+There are two ways in which one may use the notion of the Backward
+Compatibility loss with respect to the Tensorflow framework.
+
+- Creating and training a model subclassed from BCNewErrorCompatibilityModel
+- Training a general model h2 using Backward Compatibility Loss
+
+The first method for achieving this allows one to leverage the existing
+``h2.fit(...)`` method in order to train your model. However it requires
+that ``h2`` was instantiated from a model subclassed from BCNewErrorCompatibilityModel.
+If you already had a model instantiated from a distinct model class, then
+you mayneed to go through soe effort to extract the layers you need
+and wrap them within a new model class subclassed from BCNewErrorCompatibilityModel.
+
+On the other hand, the second method places no restrictions on the architecture
+of ``h2``. However we will be unable to use the existing Tensorflow
+``h2.fit(...)`` method to train our model. Instead we will need to train
+it using ``tf_helpers.bc_fit``.
+
+We go into the details of both methods below.
+
+
+Creating and training a model subclassed from BCNewErrorCompatibilityModel
+---------------------------------------------------------------------------
+
+Assuming that you have a pre-trained model ``h1`` and that you want to
+create a new model ``h2`` which is to be trained using the
+Backward Compatibility loss, with respect to ``h1`` for some value of
+``lambda_c``.
+
+With all the parameters as specified above, proceed as follows::
+
+    h1.trainable = False
+
+    h2 = BCNewErrorCompatibilityModel([
+      tf.keras.layers.Flatten(input_shape=(28, 28, 1)),
+      tf.keras.layers.Dense(128,activation='relu'),
+      tf.keras.layers.Dense(10, activation='softmax')
+    ], h1=h1, lambda_c=0.7)
+
+    h2.compile(
+        loss=tf.keras.losses.sparse_categorical_crossentropy,
+        optimizer=tf.keras.optimizers.Adam(0.001),
+        metrics=['accuracy']
+    )
+
+    h2.fit(
+        dataset_train,
+        epochs=6,
+        validation_data=dataset_test,
+    )
+
+
+An example notebook which walks you through a working example may be found at
+``./examples/tensorflow-MNIST`` from the BackwardCompatibilityML project root.
+
+
+Training a general model h2 using Backward Compatibility Loss
+--------------------------------------------------------------
+
+We assume that we have an existing pre-trained model ``h1``.
+We instantiate a model ``h2`` as a standard Sequential Keras
+model.
+
+With all the parameters as specified above, proceed as follows::
+
+    h2 = tf.keras.models.Sequential([
+      tf.keras.layers.Flatten(input_shape=(28, 28, 1)),
+      tf.keras.layers.Dense(128,activation='relu'),
+      tf.keras.layers.Dense(10, activation='softmax')
+    ])
+
+    lambda_c = 0.9
+    h1.trainable = False
+    bc_loss = BCCrossEntropyLoss(model, h2, lambda_c)
+
+    optimizer = tf.keras.optimizers.Adam(0.001)
+
+    tf_helpers.bc_fit(
+        h2,
+        training_set=ds_train,
+        testing_set=ds_test,
+        epochs=6,
+        bc_loss=bc_loss,
+        optimizer=optimizer)
+
+
+An example notebook which walks you through a working example may be found at
+``./examples/tensorflow-MNIST-generalized`` from the BackwardCompatibilityML project root.

--- a/docs/backwardcompatibilityml/topics/using_the_tensorflow_interface.rst
+++ b/docs/backwardcompatibilityml/topics/using_the_tensorflow_interface.rst
@@ -3,21 +3,21 @@
 The Tensorflow Interface
 =================================================================
 
-There are two ways in which one may use the notion of the Backward
-Compatibility loss with respect to the Tensorflow framework.
+There are two ways in which you may use the notion of the backward
+compatibility loss with respect to the Tensorflow framework.
 
 - Creating and training a model subclassed from BCNewErrorCompatibilityModel
-- Training a general model h2 using Backward Compatibility Loss
+- Training a general model h2 using backward compatibility Loss
 
-The first method for achieving this allows one to leverage the existing
-``h2.fit(...)`` method in order to train your model. However it requires
+The first method for achieving this allows you to leverage the existing
+``h2.fit(...)`` method in order to train your model. However, it requires
 that ``h2`` was instantiated from a model subclassed from BCNewErrorCompatibilityModel.
 If you already had a model instantiated from a distinct model class, then
-you mayneed to go through soe effort to extract the layers you need
+you may need to go through soe effort to extract the layers you need
 and wrap them within a new model class subclassed from BCNewErrorCompatibilityModel.
 
 On the other hand, the second method places no restrictions on the architecture
-of ``h2``. However we will be unable to use the existing Tensorflow
+of ``h2``. However, we will be unable to use the existing Tensorflow
 ``h2.fit(...)`` method to train our model. Instead we will need to train
 it using ``tf_helpers.bc_fit``.
 
@@ -28,8 +28,8 @@ Creating and training a model subclassed from BCNewErrorCompatibilityModel
 ---------------------------------------------------------------------------
 
 Assuming that you have a pre-trained model ``h1`` and that you want to
-create a new model ``h2`` which is to be trained using the
-Backward Compatibility loss, with respect to ``h1`` for some value of
+create a new model ``h2`` that is to be trained using the
+backward compatibility loss, with respect to ``h1`` for some value of
 ``lambda_c``.
 
 With all the parameters as specified above, proceed as follows::
@@ -55,11 +55,11 @@ With all the parameters as specified above, proceed as follows::
     )
 
 
-An example notebook which walks you through a working example may be found at
+An example notebook that walks you through a working example may be found at
 ``./examples/tensorflow-MNIST`` from the BackwardCompatibilityML project root.
 
 
-Training a general model h2 using Backward Compatibility Loss
+Training a general model h2 using backward compatibility loss
 --------------------------------------------------------------
 
 We assume that we have an existing pre-trained model ``h1``.
@@ -89,5 +89,5 @@ With all the parameters as specified above, proceed as follows::
         optimizer=optimizer)
 
 
-An example notebook which walks you through a working example may be found at
+An example notebook that walks you through a working example may be found at
 ``./examples/tensorflow-MNIST-generalized`` from the BackwardCompatibilityML project root.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = '2021, Microsoft'
 author = 'Besmira Nushi, Ece Kamar, Xavier Fernandes, Nicholas King, Kathleen Walker, Juan Lema, Megha Srivastava, Gagan Bansal, Dean Carignan'
 
 # The full version, including alpha/beta/rc tags
-release = '1.4.0'
+release = '1.4.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,7 @@
 # Build the Typescript app and place the javascript
 # build artefact in a plae where the Python package
 # expects it.
-NODE_ENV=production npx webpack
+NODE_ENV=production npm run build
 
 # Install the Python dependencies and the package itself
 python -m pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 
 # this must be incremented every time we push an update to pypi (but not before)
-VERSION = "1.4.0"
+VERSION = "1.4.1"
 
 # supply contents of our README file as our package's long description
 with open("README.md", "r") as fh:


### PR DESCRIPTION
This PR adds more documentation around the Tensorflow API for BackwardCompatibilityML.
