### PR TITLE
Detect submodules so that the docs generate correctly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ copyright = '2021, Microsoft'
 author = 'Besmira Nushi, Ece Kamar, Xavier Fernandes, Nicholas King, Kathleen Walker, Juan Lema, Megha Srivastava, Gagan Bansal, Dean Carignan'
 
 # The full version, including alpha/beta/rc tags
-release = '1.4.1'
+release = '1.4.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -30,16 +30,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/BackwardCompatibilityML",
 
-    # this will find our package "xtlib" by its having an "__init__.py" file
+    # Subpackages
     packages=[
-        "backwardcompatibilityml",
-        "backwardcompatibilityml.loss",
-        "backwardcompatibilityml.helpers",
-        "backwardcompatibilityml.widgets",
-        "backwardcompatibilityml.widgets.compatibility_analysis.resources",
-         "backwardcompatibilityml.widgets.model_comparison.resources"
-
-    ],  # setuptools.find_packages(),
+        setuptools.find_packages()
+    ],
 
     entry_points={
     },

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,17 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/microsoft/BackwardCompatibilityML",
 
-    # Subpackages
+    # Pckages
     packages=[
-        setuptools.find_packages()
+        "backwardcompatibilityml",
+        "backwardcompatibilityml.loss",
+        "backwardcompatibilityml.helpers",
+        "backwardcompatibilityml.widgets",
+        "backwardcompatibilityml.widgets.compatibility_analysis.resources",
+        "backwardcompatibilityml.widgets.model_comparison.resources",
+        "backwardcompatibilityml.tensorflow",
+        "backwardcompatibilityml.tensorflow.loss"
+
     ],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 
 # this must be incremented every time we push an update to pypi (but not before)
-VERSION = "1.4.1"
+VERSION = "1.4.2"
 
 # supply contents of our README file as our package's long description
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setuptools.setup(
         "backwardcompatibilityml.loss",
         "backwardcompatibilityml.helpers",
         "backwardcompatibilityml.widgets",
+        "backwardcompatibilityml.widgets.compatibility_analysis",
         "backwardcompatibilityml.widgets.compatibility_analysis.resources",
+        "backwardcompatibilityml.widgets.model_comparison",
         "backwardcompatibilityml.widgets.model_comparison.resources",
         "backwardcompatibilityml.tensorflow",
         "backwardcompatibilityml.tensorflow.loss"


### PR DESCRIPTION
The docs on Readthedocs were failing to correctly generate because the Tensorflow submodule was not being correctly detected.

This PR fixes that issue.