### PR TITLE
H1 peformance dotted line and verification that error instances calculated correctly

### DIFF
--- a/widgets/common/PerformanceCompatibility.tsx
+++ b/widgets/common/PerformanceCompatibility.tsx
@@ -113,6 +113,8 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
     var btcValues = allDataPoints.map(d => d["btc"]);
     var becValues = allDataPoints.map(d => d["bec"]);
     var allValues = [].concat(btcValues).concat(becValues);
+    var allPerformance = allDataPoints.map(d => d["performance"]);
+    var allPerformanceWithH1 = allPerformance.concat(this.props.h1Performance);
 
     var xScale = d3.scaleLinear()
       .domain([
@@ -122,8 +124,8 @@ class PerformanceCompatibility extends Component<PerformanceCompatibilityProps, 
       .range([0,w])
     var yScale = d3.scaleLinear()
       .domain([
-        d3.min(allDataPoints,function (d) { return d['performance'] }),
-        d3.max(allDataPoints,function (d) { return d['performance'] })
+        (d3.min(allPerformanceWithH1) - 0.005),
+        (d3.max(allPerformanceWithH1) + 0.005)
         ])
       .range([h,0])
 


### PR DESCRIPTION
This PR adds some UI changes so that the h1 error instance dotted line is always shown, and not hidden in the case where it overlaps exactly with the X-axis.

This PR also extends an existing test to verify that the error instances on sweep that come from the training and testing set are stored separately and do not mix.

It was also verified that the data points int he scatterplot overlapping, was not due to the value of the loss being exactly the same. But due to the BTC and BEC scores being exactly the same. This is not surprising as it just calculated from the incompatible points.